### PR TITLE
[WIP] SAV-38: syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,17 +1,29 @@
+# Basic Info
 title: Savas
 email: info@savaslabs.com
 description: > 
   A Drupal-centric web development and design shop anchored in Durham, NC.
 baseurl: "" 
 url: ""
+
+# Professional and social media links
 twitter_username: savas_labs 
 github_username: savaslabs
+
+# Languages and syntax highlighting
 markdown: kramdown
-paginate: 6
-paginate_path: "/blog/:num/"
-exclude: [vendor]
 sass:
   sass_dir: assets/styles/_scss
+pygments: true
+
+# Blog
+paginate: 6
+paginate_path: "/blog/:num/"
+
+# For Travis CI
+exclude: [vendor]
+
+# Collections
 collections:
   team:
     output: true
@@ -19,5 +31,7 @@ collections:
   work:
     output: true
     permalink: /work/:path/
+
+# Gems
 gems:
   - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ github_username: savaslabs
 markdown: kramdown
 sass:
   sass_dir: assets/styles/_scss
-pygments: true
+highlighter: pygments
 
 # Blog
 paginate: 6

--- a/_posts/2015-04-01-building-our-site.markdown
+++ b/_posts/2015-04-01-building-our-site.markdown
@@ -12,11 +12,12 @@ Initially we intended to whip up a site quickly using a Jekyll template. We had 
 After a few weeks of squeezing in work on the site when we could, it became apparent that the template wasn't going to meet our needs. The one page layout lacked the depth we wanted, and the template didn't allow us to showcase our skills as developers. We tossed around the idea of creating a site from scratch, keeping Jekyll but ditching the template. A few of us have a well-developed love of Sass and wanted to try <a href="http://bourbon.io">Bourbon</a>, a Sass mixin library, its grid system <a href="http://neat.bourbon.io">Neat</a>, and <a href="http://bourbon.io">Bitters</a>, a basic set of styles that help set up a new Sass environment. We also used a few components from <a href="http://refills.bourbon.io/">Refills</a>.
 
 Creating a new Jekyll site was a matter of a few commands:
-
-> `$ gem install jekyll`     
-> `$ jekyll new [sitename]`   
-> `$ cd [sitename]`   
-> `$ jekyll serve`  
+{% highlight bash %}
+$ gem install jekyll     
+$ jekyll new [sitename]   
+$ cd [sitename]   
+$ jekyll serve
+{% endhighlight %}  
 
 This created the file structure, and `jekyll serve` starts a local server on which the new site is running, convenient for coding on sunny patios with bad wifi. 
 
@@ -28,15 +29,19 @@ Modular partial files allowed us to organize our files semantically and avoid re
 
 Neat worked well for this site. The number of columns is set in _grid.scss (12 is the default) and we mostly used just two mixins - span-columns and shift.
 
-    div {
-	    @include span-columns(8);
-	    @include shift(2);
-    }
+{% highlight css %}
+div {
+    @include span-columns(8);
+    @include shift(2);
+}
+{% endhighlight %}
 
 This div will span 8 columns and will be offset by 2 columns, centering it in the 12-column grid. A bit more semantic than Foundation's `col-lg-8 col-lg-offset-2`
 
 To create a few repeated layouts, we used the navigation, footer, and cards Refills. This was our first experience with flexbox and we heavily referenced <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">this excellent article</a> from CSS-Tricks. Since flexbox isn't quite stable and has gone through several versions, a hefty amount of vendor prefixes are required, and this is where Bourbon became a real asset. Instead of:
 
+{% highlight css %}    
+div {
     display: -webkit-box;
     display: -moz-box;
     display: box;
@@ -44,10 +49,16 @@ To create a few repeated layouts, we used the navigation, footer, and cards Refi
     display: -moz-flex;
     display: -ms-flexbox;
     display: flex;
+}
+{% endhighlight %}
 
 ...we simply used the mixin:
 
-    @include display(flex);
+{% highlight css %}    
+    div {
+        @include display(flex);
+    }
+{% endhighlight %}
 
 In addition to flexbox, we used Bourbon's CSS3 transitions mixins, em to pixel calculations, and media query mixins. 
 

--- a/assets/styles/_scss/_syntax-highlighting.scss
+++ b/assets/styles/_scss/_syntax-highlighting.scss
@@ -1,0 +1,85 @@
+/**
+ * Syntax highlighting styles
+ */
+
+ /* from http://stackoverflow.com/a/23393920 */
+.highlight { border-radius: 8px; }
+.highlight pre {
+  border-radius: 5px;
+  border: 1px solid #eee;
+  padding: 5px 10px 10px;
+}
+.highlight pre code * {
+  white-space: nowrap;    // this sets all children inside to nowrap
+}
+.highlight pre {
+  overflow-x: auto;       // this sets the scrolling in x
+  overflow-y: hidden;
+}
+.highlight pre code {
+  white-space: pre;       // forces <code> to respect <pre> formatting
+}
+
+.highlight {
+    background: #fff;
+
+    .c     { color: #998; font-style: italic } // Comment
+    .err   { color: #a61717; background-color: #e3d2d2 } // Error
+    .k     { font-weight: bold } // Keyword
+    .o     { font-weight: bold } // Operator
+    .cm    { color: #998; font-style: italic } // Comment.Multiline
+    .cp    { color: #999; font-weight: bold } // Comment.Preproc
+    .c1    { color: #998; font-style: italic } // Comment.Single
+    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
+    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
+    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
+    .ge    { font-style: italic } // Generic.Emph
+    .gr    { color: #a00 } // Generic.Error
+    .gh    { color: #999 } // Generic.Heading
+    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
+    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
+    .go    { color: #888 } // Generic.Output
+    .gp    { color: #555 } // Generic.Prompt
+    .gs    { font-weight: bold } // Generic.Strong
+    .gu    { color: #aaa } // Generic.Subheading
+    .gt    { color: #a00 } // Generic.Traceback
+    .kc    { font-weight: bold } // Keyword.Constant
+    .kd    { font-weight: bold } // Keyword.Declaration
+    .kp    { font-weight: bold } // Keyword.Pseudo
+    .kr    { font-weight: bold } // Keyword.Reserved
+    .kt    { color: #458; font-weight: bold } // Keyword.Type
+    .m     { color: #099 } // Literal.Number
+    .s     { color: #d14 } // Literal.String
+    .na    { color: #008080 } // Name.Attribute
+    .nb    { color: #0086B3 } // Name.Builtin
+    .nc    { color: #458; font-weight: bold } // Name.Class
+    .no    { color: #008080 } // Name.Constant
+    .ni    { color: #800080 } // Name.Entity
+    .ne    { color: #900; font-weight: bold } // Name.Exception
+    .nf    { color: #900; font-weight: bold } // Name.Function
+    .nn    { color: #555 } // Name.Namespace
+    .nt    { color: #000080 } // Name.Tag
+    .nv    { color: #008080 } // Name.Variable
+    .ow    { font-weight: bold } // Operator.Word
+    .w     { color: #bbb } // Text.Whitespace
+    .mf    { color: #099 } // Literal.Number.Float
+    .mh    { color: #099 } // Literal.Number.Hex
+    .mi    { color: #099 } // Literal.Number.Integer
+    .mo    { color: #099 } // Literal.Number.Oct
+    .sb    { color: #d14 } // Literal.String.Backtick
+    .sc    { color: #d14 } // Literal.String.Char
+    .sd    { color: #d14 } // Literal.String.Doc
+    .s2    { color: #d14 } // Literal.String.Double
+    .se    { color: #d14 } // Literal.String.Escape
+    .sh    { color: #d14 } // Literal.String.Heredoc
+    .si    { color: #d14 } // Literal.String.Interpol
+    .sx    { color: #d14 } // Literal.String.Other
+    .sr    { color: #009926 } // Literal.String.Regex
+    .s1    { color: #d14 } // Literal.String.Single
+    .ss    { color: #990073 } // Literal.String.Symbol
+    .bp    { color: #999 } // Name.Builtin.Pseudo
+    .vc    { color: #008080 } // Name.Variable.Class
+    .vg    { color: #008080 } // Name.Variable.Global
+    .vi    { color: #008080 } // Name.Variable.Instance
+    .il    { color: #099 } // Literal.Number.Integer.Long
+}

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -5,6 +5,7 @@
 @import "base/grid-settings";
 @import "lib/neat/neat";
 @import "font-awesome/font-awesome";
+@import "syntax-highlighting";
 
 @import "base/base";
 @import "layout";


### PR DESCRIPTION
@kostajh This is nearly there with one big issue that I haven't been able to resolve. Pygments doesn't have Sass or scss support. I used CSS highlighting on the two blocks of scss and it looks fine except it's adding a space after "flex." I don't know why that particular word gets an extra space, or how to enable scss support.

I also tried using Rouge which does include Sass support but I wasn't able to get it working. 

Maybe we can look at this on Monday. :sadpanda:
