### PR TITLE
SAV-37: professional service schema

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,7 @@
   <script type="text/javascript" src="{{ "/assets/js/main.js" | prepend: site.baseurl }}"></script>
   {% include schema-organization.html %}
   {% if page.layout == "team" %}{% include schema-team.html %}{% endif %}
+  {% if page.permalink == "/what-we-do/" or page.permalink == "/drupal-training/" %}{% include schema-professional-service.html %}{% endif %}
   {% if page.path contains "_posts" %}{% include schema-blog.html %}{% endif %}
   {% include googleanalytics.html %}
 </head>

--- a/_includes/schema-organization.html
+++ b/_includes/schema-organization.html
@@ -8,8 +8,11 @@
         "postalCode": "27701",
         "streetAddress": "201 W Main St."
       },
+      "description": "A Drupal-centric web development and design shop anchored in Durham, NC.",
       "email": "info@savaslabs.com",
       "name": "Savas",
-      "telephone": "(919) 432-4660"
+      "telephone": "(919) 432-4660",
+      "url": "http://savaslabs.com",
+      "logo": "http://savaslabs.com/assets/img/logo.png"
     }
 </script>

--- a/_includes/schema-professional-service.html
+++ b/_includes/schema-professional-service.html
@@ -1,0 +1,17 @@
+<script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "ProfessionalService",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Durham, North Carolina",
+        "postalCode": "27701",
+        "streetAddress": "201 W Main St."
+      },
+      "description": "A Drupal-centric web development and design shop anchored in Durham, NC."
+      "logo": "http://savaslabs.com/assets/img/logo.png"
+      "email": "info@savaslabs.com",
+      "name": "Savas",
+      "telephone": "(919) 432-4660"
+    }
+</script>

--- a/_includes/schema-professional-service.html
+++ b/_includes/schema-professional-service.html
@@ -9,9 +9,10 @@
         "streetAddress": "201 W Main St."
       },
       "description": "A Drupal-centric web development and design shop anchored in Durham, NC."
-      "logo": "http://savaslabs.com/assets/img/logo.png"
       "email": "info@savaslabs.com",
       "name": "Savas",
-      "telephone": "(919) 432-4660"
+      "telephone": "(919) 432-4660",
+      "url": "http://savaslabs.com",,
+      "logo": "http://savaslabs.com/assets/img/logo.png"
     }
 </script>

--- a/_includes/schema-professional-service.html
+++ b/_includes/schema-professional-service.html
@@ -8,11 +8,11 @@
         "postalCode": "27701",
         "streetAddress": "201 W Main St."
       },
-      "description": "A Drupal-centric web development and design shop anchored in Durham, NC."
+      "description": "A Drupal-centric web development and design shop anchored in Durham, NC.",
       "email": "info@savaslabs.com",
       "name": "Savas",
       "telephone": "(919) 432-4660",
-      "url": "http://savaslabs.com",,
+      "url": "http://savaslabs.com",
       "logo": "http://savaslabs.com/assets/img/logo.png"
     }
 </script>


### PR DESCRIPTION
@kostajh I ended up updating the Organization schema to include a couple more things like logo and description and duplicating it for the Professional Services, which I added to the What we do and Training pages. There doesn't seem to be anything specific to Professional Services (opening hours, payments accepted, etc.) that would be relevant to us. Let me know if you can think of anything else to add though.

The schema docs do say that more is better, so it can't hurt. :octopus: 
