### PR TITLE
SAV-60: add resumes

### DIFF
--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -19,6 +19,9 @@ layout: default
       {% if page.website %}
         <li><i class="fa fa-globe"></i><a href="{{ page.website }}">&nbsp;&nbsp;Website</a></li>
       {% endif %}
+      {% if page.resume %}
+        <li><i class="fa fa-file-text"></i><a href="{{ page.resume }}">&nbsp;&nbsp;Resume</a></li>
+      {% endif %}
     </div>
 
     <article class="team-member-bio">

--- a/_team/anne-tomasevich.md
+++ b/_team/anne-tomasevich.md
@@ -8,5 +8,6 @@ card: "assets/img/team/cards/anne-card.jpg"
 drupal: AnneTee
 github: AnneTee
 linkedin: annetomasevich
+resume: https://careers.stackoverflow.com/annetee
 ---
 Anne received a B.S. in textile engineering and worked in the clinical research industry for five years before becoming a web developer. She brings to Savas process development, project coordination and client relations skills and is particularly interested in Sass, CSS3, and Object-Oriented CSS. When her laptop is closed, Anne enjoys cooking, playing old Zelda games, and all things musical. She plays piano (and occasionally ukulele) in local bands My Brother, My Sister and Jon Sebastian and the Tresspassers, who had a <a href="http://jonsebastian.bandcamp.com/track/nightmare-sisters">song</a> featured on NPR Music's Favorite Songs of 2014.

--- a/_team/dan-murphy.md
+++ b/_team/dan-murphy.md
@@ -8,6 +8,7 @@ card: "assets/img/team/cards/dan-card.jpg"
 drupal: dmurphy1
 github: dmurphy1
 linkedin: danielmurphyjr
+resume: https://careers.stackoverflow.com/dmurphy1
 ---
 
 Dan has worked as a web developer for the past two years specializing in the Drupal platform, developing back-end solutions and implementing responsive front-end designs. When he's not nerding-out over the latest advancements in web technology, Dan teaches math as an adjunct instructor for Northeastern University. He also loves to spend his free time rock climbing, snowboarding, and generally enjoying the great outdoors. Prior to web development, Dan worked for a multinational aerospace and defense company as a mechanical engineer. He received his B.S. in mechanical engineering from Tufts University and his M.B.A. from Babson College.

--- a/_team/kosta-harlan.md
+++ b/_team/kosta-harlan.md
@@ -10,5 +10,6 @@ github: kostajh
 twitter: kostajh
 linkedin: kostaharlan
 website: http://www.kostaharlan.net
+resume: http://resume.kostaharlan.net
 ---
 Kosta is a programmer with ten years of [web development experience](http://resume.kostaharlan.net). As director of technology at Savas, he is involved in site architecture, code review, and development. Kosta has a deep level of experience in Drupal data migration and complex site builds and is an active <a href="https://www.drupal.org/user/209141">contributor</a> to the Drupal ecosystem, in submitting patches, maintaining modules and Drush extensions. When not hacking away in Emacs, Kosta is engaged in social justice organizing, working to [improve soccer facilities in the Durham community](http://durhamatletico.com), practicing the oud and piano, and raising his son.

--- a/assets/styles/_scss/_team.scss
+++ b/assets/styles/_scss/_team.scss
@@ -62,6 +62,10 @@
             list-style-type: none;
             padding: 0 .75em;
         }
+
+        .fa-file-text {
+            font-size: 13px;
+        }
     }
 }
 


### PR DESCRIPTION
@chrisarusso @timstallmann You can add a link to your resume if you want by adding a resume attribute in the front matter of your profile file (i.e. _team/chris-russo.md). 

@kostajh review please?
