### PR TITLE
Improve drupal plant summary format

### DIFF
--- a/feed-drupal.xml
+++ b/feed-drupal.xml
@@ -14,8 +14,14 @@
     {% if post.tags contains 'drupal-planet' %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.drupal_planet_summary | xml_escape | markdownify | xml_escape | replace: '!SITE_URL', site.url' }}
-        &lt;p&gt;&lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;Continue reading…&lt;/a&gt;&lt;/p&gt;
+        <description>
+          &lt;p&gt;
+            {% if post.featured_image %}
+              &lt;img src=&quot;{{ site.url}}{{ post.featured_image }}&quot; alt=&quot;{{ post.featured_image_alt }}&quot; &gt;
+            {% endif %}
+            {{ post.drupal_planet_summary | xml_escape }}
+                &lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;Continue reading…&lt;/a&gt;
+          &lt;/p&gt;
         </description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.url }}</link>


### PR DESCRIPTION
Add possibility for a featured image

The site.url setup I've removed seems to have no effect
as expected by: f90f7711d35b6f49c53536b36b225c84885922e2

@kostajh I've rebuild the site locally with `bundle exec jekyll serve --config _config.yml` therefore using the production config file that has the site.url set, and it generates the site.url code as expected in place. I think the previous site url rewriting can be removed, but perhaps I'm misunderstanding the underlying syntax. Thoughts on this PR? The general gist is adding front matter callouts that will include an image to Drupal planet which should make them look more professional.
