### PR TITLE
Issue #890: Add redirects from news to blog

### DIFF
--- a/_includes/comment-form.html
+++ b/_includes/comment-form.html
@@ -37,7 +37,7 @@
             </div>
           </div>
 
-          <input type='submit' value='Submit' id='submit' />
+          <input type='submit' value='Submit' id='submit' class="submit-comment"/>
         </form>
       </div>
     </div>

--- a/assets/styles/scss/base/_variables.scss
+++ b/assets/styles/scss/base/_variables.scss
@@ -97,11 +97,9 @@ $expander-toggle-margin: 1em;
 
 // Mixins and abstract classes -------------------------------------------------
 %button {
-  $background: lighten($light-gray, 10%);
-  background-color: $background;
-  border: 1px solid $light-gray;
+  background-color: $action-color;
   border-radius: 3px;
-  color: $fuschia;
+  color: $base-background-color;
   font-family: $copytext-font;
   margin-top: 2em;
   padding: .75em 1em;
@@ -109,8 +107,7 @@ $expander-toggle-margin: 1em;
 
   &:hover,
   &:focus {
-    background-color: lighten($background, 5%);
-    color: $orange;
+    background-color: $action-color-hover;
   }
 }
 

--- a/assets/styles/scss/components/_comments.scss
+++ b/assets/styles/scss/components/_comments.scss
@@ -103,6 +103,10 @@
   }
   // scss-lint:enable IdSelector
 
+  .submit-comment {
+    @extend %button;
+  }
+
   // Existing comments.
   .post-comments {
     margin-top: 2.5em;

--- a/blog.html
+++ b/blog.html
@@ -2,6 +2,8 @@
 layout: page
 title: Blog
 permalink: "/blog/"
+redirect_from:
+  - /news/
 excerpt: Blabs by Savas Labs. Blog posts too!
 ---
 <p class="page-description">Check out our latest blog posts and information about upcoming events.</p>

--- a/blog/tag/best practices.md
+++ b/blog/tag/best practices.md
@@ -1,5 +1,0 @@
----
-layout: tag
-tag: best-practices
-permalink: /blog/tag/best practices/
----

--- a/blog/tag/best-practices.md
+++ b/blog/tag/best-practices.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: best-practices
 permalink: /blog/tag/best-practices/
+redirect_from:
+  - /news/tag/best-practices/
 ---

--- a/blog/tag/bourbon.md
+++ b/blog/tag/bourbon.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: bourbon
 permalink: /blog/tag/bourbon/
+redirect_from:
+  - /news/tag/bourbon/
 ---

--- a/blog/tag/bowline.md
+++ b/blog/tag/bowline.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: bowline
 permalink: /blog/tag/bowline/
+redirect_from:
+  - /news/tag/bowline/
 ---

--- a/blog/tag/business.md
+++ b/blog/tag/business.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: business
 permalink: /blog/tag/business/
+redirect_from:
+  - /news/tag/business/
 ---

--- a/blog/tag/cartography.md
+++ b/blog/tag/cartography.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: cartography
 permalink: /blog/tag/cartography/
+redirect_from:
+  - /news/tag/cartography/
 ---

--- a/blog/tag/composer.md
+++ b/blog/tag/composer.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: composer
 permalink: /blog/tag/composer/
+redirect_from:
+  - /news/tag/composer/
 ---

--- a/blog/tag/conference.md
+++ b/blog/tag/conference.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: conference
 permalink: /blog/tag/conference/
+redirect_from:
+  - /news/tag/conference/
 ---

--- a/blog/tag/css.md
+++ b/blog/tag/css.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: css
 permalink: /blog/tag/css/
+redirect_from:
+  - /news/tag/css/
 ---

--- a/blog/tag/design.md
+++ b/blog/tag/design.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: design
 permalink: /blog/tag/design/
+redirect_from:
+  - /news/tag/design/
 ---

--- a/blog/tag/docker.md
+++ b/blog/tag/docker.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: docker
 permalink: /blog/tag/docker/
+redirect_from:
+  - /news/tag/docker/
 ---

--- a/blog/tag/drupal-planet.md
+++ b/blog/tag/drupal-planet.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: drupal-planet
 permalink: /blog/tag/drupal-planet/
+redirect_from:
+  - /news/tag/drupal-planet/
 ---

--- a/blog/tag/drupal.md
+++ b/blog/tag/drupal.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: drupal
 permalink: /blog/tag/drupal/
+redirect_from:
+  - /news/tag/drupal/
 ---

--- a/blog/tag/drupal8.md
+++ b/blog/tag/drupal8.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: drupal8
 permalink: /blog/tag/drupal8/
+redirect_from:
+  - /news/tag/drupal8/
 ---

--- a/blog/tag/drupalcamp.md
+++ b/blog/tag/drupalcamp.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: drupalcamp
 permalink: /blog/tag/drupalcamp/
+redirect_from:
+  - /news/tag/drupalcamp/
 ---

--- a/blog/tag/durham.md
+++ b/blog/tag/durham.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: durham
 permalink: /blog/tag/durham/
+redirect_from:
+  - /news/tag/durham/
 ---

--- a/blog/tag/efficiency.md
+++ b/blog/tag/efficiency.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: efficiency
 permalink: /blog/tag/efficiency/
+redirect_from:
+  - /news/tag/efficiency/
 ---

--- a/blog/tag/event.md
+++ b/blog/tag/event.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: event
 permalink: /blog/tag/event/
+redirect_from:
+  - /news/tag/event/
 ---

--- a/blog/tag/front-end-dev.md
+++ b/blog/tag/front-end-dev.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: front-end-dev
 permalink: /blog/tag/front-end-dev/
+redirect_from:
+  - /news/tag/front-end-dev/
 ---

--- a/blog/tag/git.md
+++ b/blog/tag/git.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: git
 permalink: /blog/tag/git/
+redirect_from:
+  - /news/tag/git/
 ---

--- a/blog/tag/identity.md
+++ b/blog/tag/identity.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: identity
 permalink: /blog/tag/identity/
+redirect_from:
+  - /news/tag/identity/
 ---

--- a/blog/tag/jekyll.md
+++ b/blog/tag/jekyll.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: jekyll
 permalink: /blog/tag/jekyll/
+redirect_from:
+  - /news/tag/jekyll/
 ---

--- a/blog/tag/leaflet.md
+++ b/blog/tag/leaflet.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: leaflet
 permalink: /blog/tag/leaflet/
+redirect_from:
+  - /news/tag/leaflet/
 ---

--- a/blog/tag/mailchimp.md
+++ b/blog/tag/mailchimp.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: mailchimp
 permalink: /blog/tag/mailchimp/
+redirect_from:
+  - /news/tag/mailchimp/
 ---

--- a/blog/tag/module-development.md
+++ b/blog/tag/module-development.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: module-development
 permalink: /blog/tag/module-development/
+redirect_from:
+  - /news/tag/module-development/
 ---

--- a/blog/tag/osx.md
+++ b/blog/tag/osx.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: osx
 permalink: /blog/tag/osx/
+redirect_from:
+  - /news/tag/osx/
 ---

--- a/blog/tag/productivity.md
+++ b/blog/tag/productivity.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: productivity
 permalink: /blog/tag/productivity/
+redirect_from:
+  - /news/tag/productivity/
 ---

--- a/blog/tag/sass.md
+++ b/blog/tag/sass.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: sass
 permalink: /blog/tag/sass/
+redirect_from:
+  - /news/tag/sass/
 ---

--- a/blog/tag/testing.md
+++ b/blog/tag/testing.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: testing
 permalink: /blog/tag/testing/
+redirect_from:
+  - /news/tag/testing/
 ---

--- a/blog/tag/theming.md
+++ b/blog/tag/theming.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: theming
 permalink: /blog/tag/theming/
+redirect_from:
+  - /news/tag/theming/
 ---

--- a/blog/tag/tridug.md
+++ b/blog/tag/tridug.md
@@ -2,4 +2,6 @@
 layout: tag
 tag: tridug
 permalink: /blog/tag/tridug/
+redirect_from:
+  - /news/tag/tridug/
 ---


### PR DESCRIPTION
@chrisarusso I added redirects from `/news/` to `/blog/` and `/news/tag/[tag name]/` to `/blog/tag/[tag name]/`. I also deleted one tag markdown file that was an erroneous duplicate. This should do it for #890!
