### PR TITLE
Add `set -e` back to the test script

### DIFF
--- a/_tests/run-tests.sh
+++ b/_tests/run-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 bundle exec jekyll build --config _config.yml,_config.test.yml
 bundle exec scss-lint assets/styles/scss/*/*.scss
 bundle exec mdl . -c .mdlrc --git-recurse


### PR DESCRIPTION
We had removed `set -e` because html-proofer kept throwing false errors.
We should really have it, though, so that `run-tests.sh` has to either
pass 100%, or not at all.
