### PR TITLE
Issue #1096: Remove link from post summary

### DIFF
--- a/_posts/2016-04-20-squabble-comments.md
+++ b/_posts/2016-04-20-squabble-comments.md
@@ -5,7 +5,7 @@ date: 2016-04-20
 author: Kosta Harlan
 tags: jekyll
 summary: |
-  A peek under the hood at our website's commenting app, [Squabble](http://github.com/savaslabs/squabble).
+  A peek under the hood at our website's commenting app, Squabble.
 ---
 [Avid readers of our blog](/2015/04/01/building-our-site.html) know that it's built using the amazing and lovely open-source static site generator known as [Jekyll](http://jekyllrb.com/).
 


### PR DESCRIPTION
@kostajh The markup of the card was getting messed up by the link to the Squabble repo in your post summary. This is because it's trying to produce [a link within a link](http://binaryindulgence.com/wp-content/uploads/2014/02/inception.jpg), which is not possible. As our cards are currently constructed to be a full clickable area, links can't be included in the post summary. We can either not include links, or rethink the way our blog posts are displayed. For now, I've removed the link from your summary, and we can discuss more during phase 23858354 of our site redesign! 
