### PR TITLE
Add SE account variable to team page layout, update OC profile

### DIFF
--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -20,6 +20,9 @@ layout: default
       {% if page.linkedin %}
         <li><i class="fa fa-linkedin"></i><a href="https://www.linkedin.com/in/{{ page.linkedin }}">&nbsp;&nbsp;LinkedIn</a></li>
       {% endif %}
+      {% if page.stack-exchange %} 
+        <li><i class="fa fa-stack-exchange"></i><a href="http://stackexchange.com/users/{{ page.stack-exchange }}?tab=accounts">  Stack Exchange</a></li> 
+      {% endif %}
       {% if page.website %}
         <li><i class="fa fa-globe"></i><a href="{{ page.website }}">&nbsp;&nbsp;Website</a></li>
       {% endif %}

--- a/_team/oksana-cyrwus.md
+++ b/_team/oksana-cyrwus.md
@@ -8,6 +8,7 @@ card: "assets/img/team/cards/oksana-card.jpg"
 drupal: oksana-c
 github: oksana-c
 linkedin: oksanacyrwus
+stack-exchange: 6655373/oksana-c
 website: http://oksanac.com
 badges:
   - image: "assets/img/team/association_ind_member_badge.svg"


### PR DESCRIPTION
Hi @chrisarusso.  This PR adds Stack Exchange profile variable to the team member page template and adds SE profile link to my profile page.

I made a decision to go with a Stack Exchange profile link as opposed to Drupal Answers profile link. This will allow all other team members that participate on SE platform to showcase all of their profiles that exist on SE by using just one link. Also, I found that our icon font (font awesome) provides an icon for SE (which is great!).

If you think that it'd be better to use a direct link to DA platform as opposed to SE - let me know. 
Thank you.
