### PR TITLE
Issue #2095: Switch comment server url to comments.savaslabs.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: >
 # not used at all.
 baseurl: ""
 url: "http://savaslabs.com"
-comment_server_url: http://comments.savasdev.com
+comment_server_url: http://comments.savaslabs.com
 comment_server_enabled: 1
 
 # Nav links

--- a/_posts/2016-04-20-squabble-comments.md
+++ b/_posts/2016-04-20-squabble-comments.md
@@ -43,9 +43,9 @@ The basic plan for implementing our Disqus alternative was similar to the Disqus
 
 Looking around the open source landscape for the right tool to build this app, we came across [Lumen](https://lumen.laravel.com/), a slimmed down version of the well-known [Laravel](https://www.laravel.com) project. Lumen was very simple to get up and running with thanks to the [clear documentation examples](https://lumen.laravel.com/docs/5.2).
 
-The entry point of our application are some [routing rules](https://github.com/savaslabs/squabble/blob/master/app/Http/routes.php) that determine what data to give back to the user when they visit a particular API endpoint.
+The entry point of our application are some [routing rules](https://github.com/savaslabs/squabble/blob/master/source/app/Http/routes.php) that determine what data to give back to the user when they visit a particular API endpoint.
 
-From there, the requests are processed in the [CommentController](https://github.com/savaslabs/squabble/blob/master/app/Http/Controllers/CommentController.php) — depending on the request, we can create a comment, retrieve a comment, delete it, or get a quick list of all posts and the number of comments per page (we use this information on our home page and on the [News](/news) page to show the comment count per article).
+From there, the requests are processed in the [CommentController](https://github.com/savaslabs/squabble/blob/master/source/app/Http/Controllers/CommentController.php) — depending on the request, we can create a comment, retrieve a comment, delete it, or get a quick list of all posts and the number of comments per page (we use this information on our home page and on the [News](/news) page to show the comment count per article).
 
 The application runs on one of our cloud servers on Linode, and uses a SQLite backend. Because the Lumen framework is very lean, and the application does relatively little, it's very fast — the `api/comments/count` call takes ~84 ms while loading all comments (`api/comments`) takes about 125 ms.
 


### PR DESCRIPTION
This PR officially pulls the switch to use the new dockerized Squabble server! 

@kostajh before merging this, we need to do the following:
1. Make sure that https://pm.savaslabs.com/issues/2098 is completed
2. Pull down the latest database.sqlite from comments.savasdev.com and scp it into the comments.savaslabs.com server
