### PR TITLE
Issue #2240: Add links to headings in articles

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -40,7 +40,7 @@ $(document).ready(
         });
     });
 
-// Function for blog posts.
+// Functions for blog posts.
 $(document).ready(
     function () {
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -40,7 +40,7 @@ $(document).ready(
         });
     });
 
-// COMMENTS.
+// Function for blog posts.
 $(document).ready(
     function () {
 
@@ -53,6 +53,13 @@ $(document).ready(
         $('#comment-count').click(function () {
             enableCommentForm('#comment-count');
         });
+
+        // Give article headings direct links to anchors.
+        // Thanks to felicianotech at https://github.com/circleci/circleci-docs.
+        $("article h2, article h3, article h4, article h5, article h6").filter("[id]").each(function () {
+            $(this).append('<a href="#' + $(this).attr("id") + '"><i class="fa fa-link"></i></a>');
+        });
+
     });
 
 // COMMENT COUNT.

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -23,6 +23,7 @@
 @import 'scss/components/comments';
 @import 'scss/components/contact-block';
 @import 'scss/components/footer';
+@import 'scss/components/header-links';
 @import 'scss/components/home';
 @import 'scss/components/navigation';
 @import 'scss/components/post';

--- a/assets/styles/scss/components/_header-links.scss
+++ b/assets/styles/scss/components/_header-links.scss
@@ -1,0 +1,30 @@
+
+
+article {
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    a {
+      @include transition(all .2s ease-in-out);
+
+      opacity: 0;
+      padding-left: 5px;
+
+      .fa-link {
+        font-size: smaller;
+      }
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+
+    &:hover {
+      a {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/assets/styles/scss/components/_header-links.scss
+++ b/assets/styles/scss/components/_header-links.scss
@@ -4,7 +4,7 @@
  * Style heading links in articles.
  */
 
-article {
+.post article {
   h2,
   h3,
   h4,
@@ -17,7 +17,7 @@ article {
       padding-left: 5px;
 
       .fa-link {
-        font-size: smaller;
+        font-size: 50%;
       }
 
       &:hover {

--- a/assets/styles/scss/components/_header-links.scss
+++ b/assets/styles/scss/components/_header-links.scss
@@ -1,4 +1,8 @@
-
+/**
+ * @file
+ *
+ * Style heading links in articles.
+ */
 
 article {
   h2,


### PR DESCRIPTION
@chrisarusso The flavor of markdown provided by Jekyll already adds IDs to each heading in markdown files so this was pretty easy to finish up. I'm using JS to add the linked icon and CSS to show the link on hover.
