### PR TITLE
Issue #2366: Add Yonas' Stack Overflow resume page

### DIFF
--- a/_team/yonas-yanfa.md
+++ b/_team/yonas-yanfa.md
@@ -12,6 +12,7 @@ github: yonas
 twitter: yonasyanfa
 website: https://fizk.net
 linkedin: yonasyanfa
+resume: http://stackoverflow.com/cv/yonasyanfa
 ---
 
 Yonas Yanfa fell in love with open source software in 1997. He began working as


### PR DESCRIPTION
This will add the fixed Stack Overflow resume page back to Yonas' team page.
