### PR TITLE
Issues #2372, #2365: Update #moffice address, Dan's cv link, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ TODO: add info about image optimization/processing.
 
 ### Local development
 
-To serve the site, run `gulp serve`. This uses the test and dev config files for
-local development.
+To serve the site, run `gulp serve`. If you do not have Gulp installed locally
+then you can install it globally via `npm install -g gulp`. This uses the test
+and dev config files for local development.
 
 Thanks to `gulp.watch` and Browsersync, any changes you make will trigger Gulp
 to either regenerate the Jekyll site and automatically refresh your browser or,

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <ul>
       <li><h3>Location</h3></li>
       <li>Savas Labs<br />
-          PMB 114<br />
+          PMB 210<br />
           201 W Main Street, Suite 100<br />
           Durham, NC 27701<br /></li>
     </ul>

--- a/_team/dan-murphy.md
+++ b/_team/dan-murphy.md
@@ -8,6 +8,7 @@ card: "/team/cards/dan-card.jpg"
 drupal: dmurphy1
 github: dmurphy1
 linkedin: danielmurphyjr
+resume: http://stackoverflow.com/cv/dmurphy1
 ---
 
 Dan has worked as a web developer for the past three years specializing in the Drupal platform, developing back-end solutions and implementing responsive front-end designs. When he's not nerding-out over the latest advancements in web technology, Dan teaches math as an adjunct instructor for Northeastern University. He also loves to spend his free time rock climbing, snowboarding, and generally enjoying the great outdoors. Prior to web development, Dan worked for a multinational aerospace and defense company as a mechanical engineer. He received his B.S. in mechanical engineering from Tufts University and his M.B.A. from Babson College.


### PR DESCRIPTION
This PR does the following:
- Updates the #moffice address to PMB 210 from 114 ([#2372](https://pm.savaslabs.com/issues/2372))
- Updates Dan's resume link on his team page ([#2365](https://pm.savaslabs.com/issues/2365))
- Updates the `README.md` with instructions for install Gulp. When I was spinning up the site locally, I found I did not have Gulp installed and had to run `npm install -g gulp` before `gulp serve` worked for me.
