### PR TITLE
[WIP] Issue #2375: Change to 4 separate watch tasks to fix bug with watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -231,16 +231,11 @@ gulp.task('serve', ['build:local'], function() {
     // Watch image files; changes are piped to browserSync.
     gulp.watch('_assets/img/**/*', ['build:images']);
 
-    // Watch posts.
-    gulp.watch('_posts/**/*.+(md|markdown|MD)', ['build:jekyll:watch']);
-
-    // Watch drafts if --drafts flag was passed.
-    if (module.exports.drafts) {
-        gulp.watch('_drafts/*.+(md|markdown|MD)', ['build:jekyll:watch']);
-    }
-
     // Watch html and markdown files.
-    gulp.watch(['**/*.+(html|md|markdown|MD)', '!_site/**/*.*'], ['build:jekyll:watch']);
+    gulp.watch('**/*.html', ['build:jekyll:watch']);
+    gulp.watch('**/*.md', ['build:jekyll:watch']);
+    gulp.watch('**/*.markdown', ['build:jekyll:watch']);
+    gulp.watch('**/*.MD', ['build:jekyll:watch']);
 
     // Watch RSS feed XML file.
     gulp.watch('feed.xml', ['build:jekyll:watch']);


### PR DESCRIPTION
This PR tweaks the `gulp.watch()` syntax slightly to fix a bug that some Mac users were having where HTML and MD files were not being watched.
