### PR TITLE
Issue #2388: Update image path in Drupal feed

### DIFF
--- a/feed-drupal.xml
+++ b/feed-drupal.xml
@@ -18,7 +18,7 @@
           &lt;p&gt;
             {% if post.featured_image %}
               {% capture img_directory %}/assets/img{% endcapture %}
-              &lt;img src=&quot;{{ site.url}}{{ img_directory }}{{ post.featured_image }}&quot; alt=&quot;{{ post.featured_image_alt }}&quot; &gt;
+              &lt;img src=&quot;{{ site.url }}{{ img_directory }}{{ post.featured_image }}&quot; alt=&quot;{{ post.featured_image_alt }}&quot; &gt;
             {% endif %}
             {{ post.drupal_planet_summary | xml_escape }}
                 &lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;Continue reading…&lt;/a&gt;

--- a/feed-drupal.xml
+++ b/feed-drupal.xml
@@ -17,7 +17,8 @@
         <description>
           &lt;p&gt;
             {% if post.featured_image %}
-              &lt;img src=&quot;{{ site.url}}{{ post.featured_image }}&quot; alt=&quot;{{ post.featured_image_alt }}&quot; &gt;
+              {% capture img_directory %}/assets/img{% endcapture %}
+              &lt;img src=&quot;{{ site.url}}{{ img_directory }}{{ post.featured_image }}&quot; alt=&quot;{{ post.featured_image_alt }}&quot; &gt;
             {% endif %}
             {{ post.drupal_planet_summary | xml_escape }}
                 &lt;a href=&quot;{{ site.url }}{{ post.url }}&quot;&gt;Continue reading…&lt;/a&gt;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -242,8 +242,8 @@ gulp.task('serve', ['build:local'], function() {
     // Watch html and markdown files.
     gulp.watch(['**/*.+(html|md|markdown|MD)', '!_site/**/*.*'], ['build:jekyll:watch']);
 
-    // Watch RSS feed XML file.
-    gulp.watch('feed.xml', ['build:jekyll:watch']);
+    // Watch RSS feed XML files.
+    gulp.watch('**.xml', ['build:jekyll:watch']);
 
     // Watch data files.
     gulp.watch('_data/**.*+(yml|yaml|csv|json)', ['build:jekyll:watch']);


### PR DESCRIPTION
@oksana-c This should fix the image path in the Drupal feed, but I still don't know why your post is showing up twice in the link you posted. [This feed](http://feeds.feedburner.com/savas-labs-drupal-planet) looks right (besides the images of course).

I also updated the gulp serve task to watch all xml files in the repo root. :goat: :bird: :sunny:
