### PR TITLE
Issue #2363: Add Savas logo to Savasians' comments

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -143,9 +143,17 @@ function enableCommentForm($id) {
                         var name = json.data[i].name;
                         var created = json.data[i].created_at;
                         var comment = json.data[i].comment;
+                        var commentClass = 'comment';
+                        if (json.data[i].savasian == 1) {
+                            commentClass = 'comment savasian';
+                        }
 
                         // Create HTML output.
-                        outhtml = outhtml + '<div class="comment"><h5>' + name + ' says:</h5>';
+                        outhtml = outhtml + '<div class="' + commentClass + '">';
+                        if (json.data[i].savasian == 1) {
+                            outhtml = outhtml + '<img src="/assets/img/logo.png" class="comment__logo" alt="Savas Labs logo">'
+                        }
+                        outhtml = outhtml + '<h5>' + name + ' says:</h5>';
                         outhtml = outhtml + '<p class="comment-date">' + created + '</p>';
                         outhtml = outhtml + '<p class="comment-text">' + comment + '</p></div>';
                     });

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -112,6 +112,12 @@
     margin-top: 2.5em;
 
     .comment {
+      .comment__logo {
+        float: left;
+        height: 1.44em;
+        margin-right: .5em;
+      }
+
       h5 {
         margin-bottom: 0;
       }
@@ -120,6 +126,11 @@
         color: darken($light-gray, 25%);
         font-size: .9em;
         margin: .5em 0 .4em;
+      }
+
+      .comment-date,
+      .comment-text {
+        margin-left: 1em;
       }
     }
   }

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -114,8 +114,9 @@
     .comment {
       .comment__logo {
         float: left;
-        height: 1.44em;
+        height: 0.72em;
         margin-right: .5em;
+        margin-top: .48em;
       }
 
       h5 {

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -114,9 +114,9 @@
     .comment {
       .comment__logo {
         float: left;
-        height: 0.72em;
+        height: 1.44em;
         margin-right: .5em;
-        margin-top: .48em;
+        padding: .25em 0;
       }
 
       h5 {


### PR DESCRIPTION
@timstallmann This adds the Savas logo to comments with an @savaslabs.com email address. Feel free to give suggestions for style updates!

http://localhost:3000/2015/05/18/mapping-geojson.html#js-expander-trigger is a great post for local testing.

Should look like this:
<img width="787" alt="screen shot 2016-10-21 at 12 43 23 pm" src="https://cloud.githubusercontent.com/assets/8465998/19605884/fed4a418-978b-11e6-8d1b-1357bb9c6ab9.png">
