### PR TITLE
Issue #1097: schema updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Your image should be 1474px wide. Blog images should be placed in
 `_/assets/img/blog`, but you should only include `/blog/[filename].jpg` in the
 front matter of your post.
 
+Lastly, please include `featured_image_width` and `featured_image_height` in
+pixels to satisfy Google's structured data requirements.
+
 ### Syntax Highlighting
 
 Since updating to Jekyll 3.0.2 which uses Kramdown/Rouge, to use syntax

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,9 +11,9 @@
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}" />
-  {% include schema-organization.html %}
+  {% if page.permalink == "/" or page.permalink == "/team/" or page.permalink == "/mission-and-values/" or page.permalink == "/services/" or page.permalink == "/blog/" or page.permalink == "/contact/" %}{% include schema-organization.html %}{% endif %}
   {% if page.layout == "team" %}{% include schema-team.html %}{% endif %}
-  {% if page.permalink == "/what-we-do/" or page.permalink == "/drupal-training/" %}{% include schema-professional-service.html %}{% endif %}
+  {% if page.permalink == "/services/" %}{% include schema-professional-service.html %}{% endif %}
   {% if page.path contains "_posts" %}{% include schema-blog.html %}{% endif %}
   {% include googleanalytics.html %}
   <script>

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -1,54 +1,96 @@
-{% capture image_path_start %}/assets/img{% endcapture %}
-{% capture image_path %}{{ page.featured_image | prepend: image_path_start }}{% endcapture %}
 {% assign date_modified = page.date %}
 {% if page.date_modified %}
   {% assign date_modified = page.date_modified %}
 {% endif %}
-<script type="application/ld+json">
-  {
-    "@context": "http://schema.org",
-    "@type": "BlogPosting",
-    "about": "{{ page.summary }}",
-    "articleBody": "{{ content | escape }}",
-    "author": {
+
+{% if page.featured_image %}
+  {% capture image_path_start %}/assets/img{% endcapture %}
+  {% capture image_path %}{{ page.featured_image | prepend: image_path_start }}{% endcapture %}
+  <script type="application/ld+json">
+    {
       "@context": "http://schema.org",
-      "@type": "Person",
-      "name": "{{ page.author }}",
-      "affiliation": "Savas Labs",
-      "worksFor": "Savas Labs"
-    },
-    "dateCreated": "{{ page.date }}",
-    "dateModified": "{{ date_modified }}",
-    "datePublished": "{{ page.date }}",
-    "headline": "{{ page.title }}",
-    "image": {
-      "@context": "http://schema.org",
-      "@type": "ImageObject",
-      "author": "{{ page.author }}",
+      "@type": "BlogPosting",
+      "about": "{{ page.summary }}",
+      "articleBody": "{{ content | escape }}",
+      "author": {
+        "@context": "http://schema.org",
+        "@type": "Person",
+        "name": "{{ page.author }}",
+        "affiliation": "Savas Labs",
+        "worksFor": "Savas Labs"
+      },
+      "dateCreated": "{{ page.date }}",
+      "dateModified": "{{ date_modified }}",
       "datePublished": "{{ page.date }}",
-      "description": "{{ page.featured_image_alt }}",
-      "height": "{{ page.featured_image_height }}",
-      "url": "{{ image_path | prepend: site.url }}",
-      "width": "{{ page.featured_image_width }}"
-    },
-    "inLanguage": "en-US",
-    "keywords": "{{ page.tags | join: ', ' }}",
-    "mainEntityOfPage": "{{ page.url | prepend: site.url }}",
-    "publisher": {
-      "@context": "http://schema.org",
-      "@type": "Organization",
-      "name": "Savas Labs",
-      "logo": {
+      "headline": "{{ page.title }}",
+      "image": {
         "@context": "http://schema.org",
         "@type": "ImageObject",
-        "description": "Savas Labs logo",
-        "height": "50px",
-        "url": "http://savaslabs.com/assets/img/logo.png",
-        "width": "114px"
-      }
-    },
-    "sourceOrganization": "Savas Labs",
-    "text": "{{ content | escape | textify }}",
-    "url": "{{ page.url | prepend: site.url }}"
-  }
-</script>
+        "author": "{{ page.author }}",
+        "datePublished": "{{ page.date }}",
+        "description": "{{ page.featured_image_alt }}",
+        "height": "{{ page.featured_image_height }}",
+        "url": "{{ image_path | prepend: site.url }}",
+        "width": "{{ page.featured_image_width }}"
+      },
+      "inLanguage": "en-US",
+      "keywords": "{{ page.tags | join: ', ' }}",
+      "mainEntityOfPage": "{{ page.url | prepend: site.url }}",
+      "publisher": {
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "Savas Labs",
+        "logo": {
+          "@context": "http://schema.org",
+          "@type": "ImageObject",
+          "description": "Savas Labs logo",
+          "height": "50px",
+          "url": "http://savaslabs.com/assets/img/logo.png",
+          "width": "114px"
+        }
+      },
+      "sourceOrganization": "Savas Labs",
+      "text": "{{ content | escape | textify }}",
+      "url": "{{ page.url | prepend: site.url }}"
+    }
+  </script>
+{% else %}
+<script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "BlogPosting",
+      "about": "{{ page.summary }}",
+      "articleBody": "{{ content | escape }}",
+      "author": {
+        "@context": "http://schema.org",
+        "@type": "Person",
+        "name": "{{ page.author }}",
+        "affiliation": "Savas Labs",
+        "worksFor": "Savas Labs"
+      },
+      "dateCreated": "{{ page.date }}",
+      "dateModified": "{{ date_modified }}",
+      "datePublished": "{{ page.date }}",
+      "headline": "{{ page.title }}",
+      "inLanguage": "en-US",
+      "keywords": "{{ page.tags | join: ', ' }}",
+      "mainEntityOfPage": "{{ page.url | prepend: site.url }}",
+      "publisher": {
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "Savas Labs",
+        "logo": {
+          "@context": "http://schema.org",
+          "@type": "ImageObject",
+          "description": "Savas Labs logo",
+          "height": "50px",
+          "url": "http://savaslabs.com/assets/img/logo.png",
+          "width": "114px"
+        }
+      },
+      "sourceOrganization": "Savas Labs",
+      "text": "{{ content | escape | textify }}",
+      "url": "{{ page.url | prepend: site.url }}"
+    }
+  </script>
+{% endif %}}

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -39,7 +39,14 @@
       "publisher": {
         "@context": "http://schema.org",
         "@type": "Organization",
-        "name": "Savas Labs",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Durham, North Carolina",
+          "postalCode": "27701",
+          "streetAddress": "201 W Main St."
+        },
+        "description": "{{ site.description }}",
+        "email": "info@savaslabs.com",
         "logo": {
           "@context": "http://schema.org",
           "@type": "ImageObject",
@@ -47,7 +54,10 @@
           "height": "50px",
           "url": "http://savaslabs.com/assets/img/logo.png",
           "width": "114px"
-        }
+        },
+        "name": "Savas Labs",
+        "telephone": "(919) 432-4660",
+        "url": "http://savaslabs.com"
       },
       "sourceOrganization": "Savas Labs",
       "text": "{{ content | escape | textify }}",

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -11,7 +11,7 @@
       "@context": "http://schema.org",
       "@type": "BlogPosting",
       "about": "{{ page.summary }}",
-      "articleBody": "{{ content | escape }}",
+      "articleBody": "{{ page.content | escape }}",
       "author": {
         "@context": "http://schema.org",
         "@type": "Person",
@@ -60,7 +60,7 @@
         "url": "http://savaslabs.com"
       },
       "sourceOrganization": "Savas Labs",
-      "text": "{{ content | escape | textify }}",
+      "text": "{{ page.content | escape | textify }}",
       "url": "{{ page.url | prepend: site.url }}"
     }
   </script>

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -1,3 +1,9 @@
+{% capture image_path_start %}/assets/img{% endcapture %}
+{% capture image_path %}{{ page.featured_image | prepend: image_path_start }}{% endcapture %}
+{% assign date_modified = page.date %}
+{% if page.date_modified %}
+  {% assign date_modified = page.date_modified %}
+{% endif %}
 <script type="application/ld+json">
   {
     "@context": "http://schema.org",
@@ -17,7 +23,32 @@
     "sourceOrganization": "Savas Labs",
     "inLanguage": "en-US",
     "dateCreated": "{{ page.date }}",
+    "dateModified": "{{ date_modified }}",
     "datePublished": "{{ page.date }}",
-    "url": "{{ page.url | prepend: site.url }}"
+    "url": "{{ page.url | prepend: site.url }}",
+    "image": {
+      "@context": "http://schema.org",
+      "@type": "ImageObject",
+      "author": "{{ page.author }}",
+      "datePublished": "{{ page.date }}",
+      "description": "{{ page.featured_image_alt }}",
+      "height": "{{ page.featured_image_height }}",
+      "url": "{{ image_path | prepend: site.url }}",
+      "width": "{{ page.featured_image_width }}"
+    },
+    "publisher": {
+      "@context": "http://schema.org",
+      "@type": "Organization",
+      "name": "Savas Labs",
+      "logo": {
+        "@context": "http://schema.org",
+        "@type": "ImageObject",
+        "description": "Savas Labs logo",
+        "height": "50px",
+        "url": "http://savaslabs.com/assets/img/logo.png",
+        "width": "114px"
+      }
+    },
+    "mainEntityOfPage": "{{ page.url | prepend: site.url }}"
   }
 </script>

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -8,24 +8,19 @@
   {
     "@context": "http://schema.org",
     "@type": "BlogPosting",
-    "headline": "{{ page.title }}",
     "about": "{{ page.summary }}",
     "articleBody": "{{ content | escape }}",
-      "author": {
-          "@context": "http://schema.org",
-          "@type": "Person",
-          "name": "{{ page.author }}",
-          "affiliation": "Savas Labs",
-          "worksFor": "Savas Labs"
-      },
-    "keywords": "{{ page.tags | join: ', ' }}",
-    "text": "{{ content | escape | textify }}",
-    "sourceOrganization": "Savas Labs",
-    "inLanguage": "en-US",
+    "author": {
+      "@context": "http://schema.org",
+      "@type": "Person",
+      "name": "{{ page.author }}",
+      "affiliation": "Savas Labs",
+      "worksFor": "Savas Labs"
+    },
     "dateCreated": "{{ page.date }}",
     "dateModified": "{{ date_modified }}",
     "datePublished": "{{ page.date }}",
-    "url": "{{ page.url | prepend: site.url }}",
+    "headline": "{{ page.title }}",
     "image": {
       "@context": "http://schema.org",
       "@type": "ImageObject",
@@ -36,6 +31,9 @@
       "url": "{{ image_path | prepend: site.url }}",
       "width": "{{ page.featured_image_width }}"
     },
+    "inLanguage": "en-US",
+    "keywords": "{{ page.tags | join: ', ' }}",
+    "mainEntityOfPage": "{{ page.url | prepend: site.url }}",
     "publisher": {
       "@context": "http://schema.org",
       "@type": "Organization",
@@ -49,6 +47,8 @@
         "width": "114px"
       }
     },
-    "mainEntityOfPage": "{{ page.url | prepend: site.url }}"
+    "sourceOrganization": "Savas Labs",
+    "text": "{{ content | escape | textify }}",
+    "url": "{{ page.url | prepend: site.url }}"
   }
 </script>

--- a/_includes/schema-organization.html
+++ b/_includes/schema-organization.html
@@ -1,18 +1,25 @@
 <script type="application/ld+json">
-    {
+  {
+    "@context": "http://schema.org",
+    "@type": "Organization",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Durham, North Carolina",
+      "postalCode": "27701",
+      "streetAddress": "201 W Main St."
+    },
+    "description": "{{ site.description }}",
+    "email": "info@savaslabs.com",
+    "logo": {
       "@context": "http://schema.org",
-      "@type": "Organization",
-      "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Durham, North Carolina",
-        "postalCode": "27701",
-        "streetAddress": "201 W Main St."
-      },
-      "description": "{{ site.description }}",
-      "email": "info@savaslabs.com",
-      "name": "Savas Labs",
-      "telephone": "(919) 432-4660",
-      "url": "http://savaslabs.com",
-      "logo": "http://savaslabs.com/assets/img/logo.png"
-    }
+      "@type": "ImageObject",
+      "description": "Savas Labs logo",
+      "height": "50px",
+      "url": "http://savaslabs.com/assets/img/logo.png",
+      "width": "114px"
+    },
+    "name": "Savas Labs",
+    "telephone": "(919) 432-4660",
+    "url": "http://savaslabs.com"
+  }
 </script>

--- a/_posts/2015-12-10-drupal-6-part-2.md
+++ b/_posts/2015-12-10-drupal-6-part-2.md
@@ -7,6 +7,8 @@ tags: drupal drupal8 drupal-planet
 summary: What are the risks of running a Drupal 6 site in the wild after EOL?
 featured_image: "/blog/crossed-out-angel.jpg"
 featured_image_alt: "Crossed out angel"
+featured_image_height: "349px"
+featured_image_width: "450px"
 drupal_planet_summary: |
   Part 2 of a series investigating what to do with your Drupal 6 site as
   EOL approaches. This post takes a deep dive into the risks specifically.

--- a/_posts/2016-01-22-composer-mailchimp-subscriptions.md
+++ b/_posts/2016-01-22-composer-mailchimp-subscriptions.md
@@ -7,6 +7,8 @@ tags: drupal drupal-planet composer module-development mailchimp
 summary: Using Composer Manager and the MailChimp PHP library we can simply and easily subscribe users to mailing lists without using the MailChimp contributed module.
 featured_image: "/blog/composer.jpg"
 featured_image_alt: "composer"
+featured_image_height: "447px"
+featured_image_width: "670px"
 drupal_planet_summary: |
   A demonstration on how to use Composer Manager and the MailChimp PHP library to simply and easily subscribe users to mailing lists without using the MailChimp contributed module.
 ---

--- a/_posts/2016-01-25-drupal-6-part-3.md
+++ b/_posts/2016-01-25-drupal-6-part-3.md
@@ -7,6 +7,8 @@ tags: drupal drupal8 drupal-planet
 summary: What are your options while running a Drupal 6 site in the wild after EOL?
 featured_image: "/blog/options.jpg"
 featured_image_alt: "a highway-looking sign with arrows pointing to many possibilities"
+featured_image_height: "533px"
+featured_image_width: "834px"
 drupal_planet_summary:
   Part 3 of a series investigating what options you have with your Drupal 6 site
   as EOL approaches. We discuss what your options really are given the many

--- a/_posts/2016-02-24-drupal-6-part-4.md
+++ b/_posts/2016-02-24-drupal-6-part-4.md
@@ -7,6 +7,8 @@ tags: drupal drupal8 drupal-planet
 summary: Which should you choose in upgrading your Drupal 6 site, Drupal 7 or 8?
 featured_image: "/blog/retirement.jpg"
 featured_image_alt: "a retirement sign at the beach"
+featured_image_height: "319px"
+featured_image_width: "500px"
 drupal_planet_summary:
   Part 4 of a series investigating what options you have with your Drupal 6 site
   as EOL has now come. We discuss whether Drupal 7 or Drupal 8 make sense for your

--- a/_posts/2016-03-21-an-event-apart-nashville.md
+++ b/_posts/2016-03-21-an-event-apart-nashville.md
@@ -7,7 +7,8 @@ tags: conference design front-end-dev
 summary: Some recap and reflection after my first An Event Apart conference.
 featured_image: "/blog/aea_nashville_hero.jpg"
 featured_image_alt: "An Event Apart: Nashville logo over Broadway Street"
-
+featured_image_height: "830px"
+featured_image_width: "1474px"
 ---
 
 Sitting in the Nashville airport after attending

--- a/_posts/2016-05-26-installing-xhprof.md
+++ b/_posts/2016-05-26-installing-xhprof.md
@@ -7,6 +7,8 @@ tags: php performance drupal drupal-planet module-development
 summary: Step-by-step, how to install and use XHProf to profile your Drupal module.
 featured_image: "/blog/xhprof-callgraph.jpg"
 featured_image_alt: "an XHProf callgraph"
+featured_image_height: "1000px"
+featured_image_width: "1000px"
 drupal_planet_summary:
   First part in a series of how to use XHProf effectively within a VM for a Drupal website.
 ---

--- a/_posts/2016-06-15-git-merge-conflict-strategies.md
+++ b/_posts/2016-06-15-git-merge-conflict-strategies.md
@@ -7,6 +7,8 @@ tags: git
 summary: An overview of strategies and tools I like to use when I encounter conflicts during merges.
 featured_image: "blog/git_merge_conflict_screenshot.jpg"
 featured_image_alt: "screenshot of git merge output"
+featured_image_height: "288px"
+featured_image_width: "885px"
 ---
 
 If you use Git for version control and you collaborate frequently, then you are bound to run into merge conflicts from time to time.

--- a/_posts/2016-06-22-user-testing.md
+++ b/_posts/2016-06-22-user-testing.md
@@ -7,6 +7,8 @@ tags: user-experience best-practices
 summary: Our approach to designing, conducting, and learning from user testing and other analyses.
 featured_image: "/blog/usability-testing.jpg"
 featured_image_alt: "Two people comparing notes while using computers"
+featured_image_height: "984px"
+featured_image_width: "1474px"
 ---
 
 One of my favorite lines about usability testing comes from Jakob Nielson of the Nielson Norman Group in his article [Why You Only Need to Test with 5 Users](https://www.nngroup.com/articles/why-you-only-need-to-test-with-5-users/), regarding a graph of number of user test participants versus percentage of usability problems found:

--- a/_posts/2016-09-23-supercharged-seo-with-drupal-8.md
+++ b/_posts/2016-09-23-supercharged-seo-with-drupal-8.md
@@ -7,6 +7,8 @@ tags: drupal drupal8 drupal-planet marketing
 summary: SEO trends 2017 and Drupal 8 as the best option for your long-term marketing campaign.
 featured_image: "/blog/supercharged-seo-with-drupal-8.jpg"
 featured_image_alt: "Supercharged SEO with Drupal 8"
+featured_image_height: "627px"
+featured_image_width: "1280px"
 drupal_planet_summary:
   SEO trends 2017 and an in depth look at Drupal 8's new features that make Drupal the best option for your long-term marketing campaign.
 ---

--- a/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
+++ b/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
@@ -8,6 +8,8 @@ summary: |
   How we improved our company site's performance with a better Jekyll workflow
 featured_image: "/blog/test-tubes.jpg"
 featured_image_alt: "Test tubes with brightly color liquids inside"
+featured_image_height: "912px"
+featured_image_width: "1474px"
 ---
 
 It's hard to believe it's been over a year and a half since our site's

--- a/_posts/2016-10-25-deploy-jekyll-with-travis.md
+++ b/_posts/2016-10-25-deploy-jekyll-with-travis.md
@@ -6,6 +6,8 @@ author: Anne Tomasevich
 tags: jekyll travis
 featured_image: "/blog/travis-hero.png"
 featured_image_alt: "Jekyll, Gulp, Travis, and GitHub logos"
+featured_image_height: "739px"
+featured_image_width: "1474px"
 summary: |
   A step-by-step guide to how we deploy our gulpified Jekyll site to GitHub
   Pages using Travis, opening the door for us to use Jekyll Plugins.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -219,7 +219,7 @@ gulp.task('serve', ['build:local'], function() {
     });
 
     // Watch site settings.
-    gulp.watch(['_config.yml'], ['build:jekyll:watch']);
+    gulp.watch(['_config*.yml'], ['build:jekyll:watch']);
 
     // Watch .scss files; changes are piped to browserSync.
     gulp.watch('_assets/styles/**/*.scss', ['build:styles']);

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 ---
+permalink: "/"
 ---
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
This PR contains updates to schema for [issue 1097](https://pm.savaslabs.com/issues/1097).
## Issue #1089 - blogPosting updates

To test with [ngrok](https://ngrok.com/):
1. Spin up your local site with `gulp serve`
2. Once it's up, run `./ngrok http 3000` wherever you have ngrok installed
3. Copy the URL (e.g. http://f7acdf90.ngrok.io) and add the following line to `_config.dev.yml`:
  `url: http://f7acdf90.ngrok.io`
(But use your own URL obviously)
4. Go to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) and input the URL of a blog post with a featured image (e.g. http://f7acdf90.ngrok.io/2016/10/19/optimizing-jekyll-with-gulp.html). You shouldn't see any errors or warnings, and all the schema should look good (scroll down for most of the new stuff)
5. If you run it on a post without a featured image (e.g. /2016/06/16/using-xhprof.html) you'll just see one error, that the image is required.
## Issue #2405 - articleBody

When testing the above, check out articleBody and text - they should only contain the actual article text (well, markup) and not the title, tags, comments, etc.
## Issue #2404 - organization

With this change, the organization schema should only display on the home page and other top-level pages (e.g. /team and /services) but not individual team pages and blog posts.

If no one has the time or inclination to test this we could also just merge it and test on the live site.
