### PR TITLE
Issue #2522: Update case study services links

### DIFF
--- a/_case-studies/allbooks-case-study.md
+++ b/_case-studies/allbooks-case-study.md
@@ -19,7 +19,7 @@ project_process: |
 project_results: |
   Our importer processed MIT Press's next import of new titles smoothly with a minimum of manual input. We've continued to work with the Press to further customize field mappings and import processes as new fields come online in the AllBooks database, and to handle new kinds of imports, including eBooks.
 services_provided: |
-  - [Drupal custom module development](/services#development/)
+  - [Drupal custom module development](/services#development)
   - [Unit testing](/services#testing)
 technologies_used: |
   - [Drupal 6](/blog/tag/drupal/)

--- a/_case-studies/allbooks-case-study.md
+++ b/_case-studies/allbooks-case-study.md
@@ -19,11 +19,11 @@ project_process: |
 project_results: |
   Our importer processed MIT Press's next import of new titles smoothly with a minimum of manual input. We've continued to work with the Press to further customize field mappings and import processes as new fields come online in the AllBooks database, and to handle new kinds of imports, including eBooks.
 services_provided: |
-  - [Drupal custom module development](/blog/tag/drupal/)
-  - Unit testing
+  - [Drupal custom module development](/services#development/)
+  - [Unit testing](/services#testing)
 technologies_used: |
-  - Drupal 6
-  - PHPUnit
+  - [Drupal 6](/blog/tag/drupal/)
+  - [PHPUnit](/blog/tag/testing/)
 client_logo: "/assets/img/work/allbooks-case-study/mitpress-logo.png"
 client_logo_width: "110px"
 client_logo_height: "107px"

--- a/_case-studies/civil-rights-map-case-study.md
+++ b/_case-studies/civil-rights-map-case-study.md
@@ -20,7 +20,7 @@ project_process: |
 project_results: |
   The Durham Civil and Human Rights History Map now has a beautifully-designed, and responsive, online home, which visitors and native Durhamites alike can use to tour the city. Savas Labs has also written a [number](/2015/06/10/d8-theming-basics.html) [of](/2015/07/06/map-in-drupal-8.html) [highly-viewed](/2015/05/18/mapping-geojson.html) [blog](/2015/09/03/sassy-drupal-theming-part-3.html) [posts](/2015/11/05/drupal-web-mapping.html) documenting what we've learned about Drupal 8 theming and mapping from the project.
 services_provided: |
-  - [Web design](/services#design)
+  - [Web design](/services#design-ux)
   - [Drupal theming and site building](/blog/tag/theming/)
   - [Map integration](/services#integrations)
   - [Drupal contributed module development](/services#development)

--- a/_case-studies/civil-rights-map-case-study.md
+++ b/_case-studies/civil-rights-map-case-study.md
@@ -20,14 +20,15 @@ project_process: |
 project_results: |
   The Durham Civil and Human Rights History Map now has a beautifully-designed, and responsive, online home, which visitors and native Durhamites alike can use to tour the city. Savas Labs has also written a [number](/2015/06/10/d8-theming-basics.html) [of](/2015/07/06/map-in-drupal-8.html) [highly-viewed](/2015/05/18/mapping-geojson.html) [blog](/2015/09/03/sassy-drupal-theming-part-3.html) [posts](/2015/11/05/drupal-web-mapping.html) documenting what we've learned about Drupal 8 theming and mapping from the project.
 services_provided: |
-  - [Web map design](/blog/tag/cartography)
-  - [Drupal theming and site-building](/blog/tag/theming/)
-  - [Drupal contrib module development](/blog/tag/drupal/)
+  - [Web design](/services#design)
+  - [Drupal theming and site building](/blog/tag/theming/)
+  - [Map integration](/services#integrations)
+  - [Drupal contributed module development](/services#development)
 technologies_used: |
-  - Drupal 8
-  - Leaflet
-  - Pantheon
-  - Responsive design
+  - [Drupal 8](/blog/tag/drupal8)
+  - [Leaflet](/blog/tag/cartography)
+  - [Pantheon](/blog/tag/drupal)
+  - [Responsive design](/blog/tag/front-end-dev)
 client_logo: "/assets/img/work/civil-rights-map-case-study/pauli-murray-logo.png"
 client_logo_width: "300px"
 client_logo_height: "72px"

--- a/_case-studies/cognet-case-study.md
+++ b/_case-studies/cognet-case-study.md
@@ -19,14 +19,15 @@ project_process: |
 project_results: |
   MIT Press CogNet went from a desktop-only site to a clean, modern, easy to navigate site on all screen sizes. Thanks to our strong partnership with the client, effective planning, and the powerful technologies used, this project was delivered under budget.
 services_provided: |
-  - [Responsive design](/blog/tag/front-end-dev/)
+  - [Web design](/services#design)
   - [Drupal theme development](/blog/tag/theming/)
-  - [Drupal custom module development](/blog/tag/drupal/)
+  - [Drupal custom module development](/services#development)
 technologies_used: |
-  - Drupal 7
-  - Zurb Foundation theme
-  - Sass
-  - jQuery
+  - [Drupal 7](/blog/tag/drupal)
+  - [Zurb Foundation theme](/blog/tag/theming)
+  - [Responsive design](/blog/tag/front-end-dev/)
+  - [Sass](/blog/tag/sass)
+  - [jQuery](/blog/tag/javascript)
 client_logo: "/assets/img/work/cognet-case-study/cognet_logo.png"
 client_logo_width: "325px"
 client_logo_height: "60px"

--- a/_case-studies/cognet-case-study.md
+++ b/_case-studies/cognet-case-study.md
@@ -19,7 +19,7 @@ project_process: |
 project_results: |
   MIT Press CogNet went from a desktop-only site to a clean, modern, easy to navigate site on all screen sizes. Thanks to our strong partnership with the client, effective planning, and the powerful technologies used, this project was delivered under budget.
 services_provided: |
-  - [Web design](/services#design)
+  - [Web design](/services#design-ux)
   - [Drupal theme development](/blog/tag/theming/)
   - [Drupal custom module development](/services#development)
 technologies_used: |

--- a/_case-studies/duke-today-case-study.md
+++ b/_case-studies/duke-today-case-study.md
@@ -21,14 +21,15 @@ project_process: |
 project_results: |
  With a focus on swift execution, we delivered the quality the Duke brand demands efficiently while surfacing valuable investments in best practices for security, monitoring and performance. The results were celebrated across the University. In four months, we took sixteen years and 120,000 articles worth of rich inter-departmental content and, through Cuberis's thoughtful design, made it more engaging and accessible for the broad and distributed Duke community.
 services_provided: |
-  - Standard Audit
-  - [Drupal 6 to 7 migration](/blog/tag/drupal)
-  - [Drupal theming and site-building](/blog/tag/theming/)
-  - [Drupal custom module development](/blog/tag/drupal/)
+  - [Standard Audit](/services#audit)
+  - [Drupal 6 to 7 migration](/services#migration)
+  - [Drupal theming and site-building](/blog/tag/theming)
+  - [Drupal custom module development](/services#development)
+  - [Performance improvements](/services#performance)
 technologies_used: |
-  - Drupal 7
-  - Migrate module
-  - Docker
+  - [Drupal 7](/blog/tag/drupal)
+  - [Migrate module](/blog/tag/migration)
+  - [Docker](/blog/tag/docker)
 client_logo: "/assets/img/work/duke-today-case-study/duke-today-logo.png"
 client_logo_width: "268px"
 client_logo_height: "74px"

--- a/_case-studies/duke-today-case-study.md
+++ b/_case-studies/duke-today-case-study.md
@@ -21,7 +21,7 @@ project_process: |
 project_results: |
  With a focus on swift execution, we delivered the quality the Duke brand demands efficiently while surfacing valuable investments in best practices for security, monitoring and performance. The results were celebrated across the University. In four months, we took sixteen years and 120,000 articles worth of rich inter-departmental content and, through Cuberis's thoughtful design, made it more engaging and accessible for the broad and distributed Duke community.
 services_provided: |
-  - [Standard Audit](/services#audit)
+  - [Standard Audit](/services#audits)
   - [Drupal 6 to 7 migration](/services#migration)
   - [Drupal theming and site-building](/blog/tag/theming)
   - [Drupal custom module development](/services#development)

--- a/_case-studies/hptn-case-study.md
+++ b/_case-studies/hptn-case-study.md
@@ -20,18 +20,17 @@ project_process: |
 project_results: |
   Thanks to an integrated approach in which Savas Labs worked closely with the client, the new site launched in time for the HPTN Annual Conference, the ongoing maintenance and administration of the content decreased dramatically, and both the corporate site maintainers and the remote users reaped the benefits of the easily navigable, mobile-friendly delivery of data.
 services_provided: |
-  - [Responsive web design](/blog/tag/front-end-dev/)
+  - [Web design](/services#design)
   - [User Experience consulting](/blog/tag/user-experience/)
-  - [Drupal theme development](/blog/tag/theming/)
-  - [Drupal 8 custom site build](/blog/tag/drupal8/)
-  - [Drupal 8 custom module development](/blog/tag/drupal/)
+  - [Drupal 8 custom theme and site build](/blog/tag/theming)
+  - [Drupal 8 custom module development](/services#development)
 technologies_used: |
-  - Drupal 8
-  - Memcached
-  - Varnish
+  - [Drupal 8](/blog/tag/drupal8/)
+  - [Responsive web design](/blog/tag/front-end-dev/)
+  - [Memcached](/blog/tag/performance)
+  - [Varnish](/blog/tag/performance)
   - Microsoft SQL Server data integration
   - Microsoft Azure Cloud Services
-
 client_logo: "/assets/img/work/hptn-case-study/hptn-logo.png"
 client_logo_width: "229"
 client_logo_height: "91"

--- a/_case-studies/hptn-case-study.md
+++ b/_case-studies/hptn-case-study.md
@@ -20,7 +20,7 @@ project_process: |
 project_results: |
   Thanks to an integrated approach in which Savas Labs worked closely with the client, the new site launched in time for the HPTN Annual Conference, the ongoing maintenance and administration of the content decreased dramatically, and both the corporate site maintainers and the remote users reaped the benefits of the easily navigable, mobile-friendly delivery of data.
 services_provided: |
-  - [Web design](/services#design)
+  - [Web design](/services#design-ux)
   - [User Experience consulting](/blog/tag/user-experience/)
   - [Drupal 8 custom theme and site build](/blog/tag/theming)
   - [Drupal 8 custom module development](/services#development)

--- a/_case-studies/hunter-boots-case-study.md
+++ b/_case-studies/hunter-boots-case-study.md
@@ -19,14 +19,15 @@ project_process: |
 project_results: |
   The Hunter Boots website won [Acquia's BlueDrop award](http://2014.bluedropawards.org/blog-entry/2014-blue-drop-award-winners-are-announced) for best Marketplace/eCommerce site in 2014!
 services_provided: |
-  - [Responsive design](/blog/tag/front-end-dev/)
+  - [Web design](/services#design)
   - [Drupal theme development](/blog/tag/theming/)
-  - [Drupal custom module development](/blog/tag/drupal/)
-  - Third party data integration
+  - [Drupal custom module development](/services#development)
+  - [Third party data integration](/services#integration)
 technologies_used: |
-  - Drupal 7
-  - Drupal Commerce
-  - jQuery
+  - [Drupal 7](/blog/tag/drupal)
+  - [Drupal Commerce](/blog/tag/payment-processing)
+  - [Responsive design](/blog/tag/front-end-dev/)
+  - [jQuery](/blog/tag/javascript)
 client_logo: "/assets/img/work/hunter-boots-case-study/hunter_logo.svg"
 client_logo_width: "120px"
 client_logo_height: "50px"

--- a/_case-studies/hunter-boots-case-study.md
+++ b/_case-studies/hunter-boots-case-study.md
@@ -19,10 +19,10 @@ project_process: |
 project_results: |
   The Hunter Boots website won [Acquia's BlueDrop award](http://2014.bluedropawards.org/blog-entry/2014-blue-drop-award-winners-are-announced) for best Marketplace/eCommerce site in 2014!
 services_provided: |
-  - [Web design](/services#design)
+  - [Web design](/services#design-ux)
   - [Drupal theme development](/blog/tag/theming/)
   - [Drupal custom module development](/services#development)
-  - [Third party data integration](/services#integration)
+  - [Third party data integration](/services#integrations)
 technologies_used: |
   - [Drupal 7](/blog/tag/drupal)
   - [Drupal Commerce](/blog/tag/payment-processing)

--- a/_case-studies/transaction-advisors-case-study.md
+++ b/_case-studies/transaction-advisors-case-study.md
@@ -19,18 +19,19 @@ project_process: |
 project_results: |
   Thanks to an agile approach in which we worked closely with our client, the new sites launched in time for an important conference, the administrative burden from running three separate websites was reduced, and both the customers and the business felt the benefit of easy to manage subscriptions.
 services_provided: |
-  - [Responsive design](/blog/tag/front-end-dev/)
+  - [Web design](/services#design)
   - [Drupal theme development](/blog/tag/theming/)
-  - [Drupal custom module development](/blog/tag/drupal/)
-  - Multisite
-  - Payment processing
-  - Migration
+  - [Drupal custom module development](/services#development)
+  - [Multisite](/services#drupal)
+  - [Payment processing](/services#integrations)
+  - [Migration](/services#migration)
 technologies_used: |
-  - Drupal 7
-  - Stripe payment processor
-  - Drupal Domain Access
-  - Drupal Feeds
-  - jQuery
+  - [Drupal 7](/blog/tag/drupal)
+  - [Stripe payment processor](/blog/tag/payment-processing)
+  - [Drupal Domain Access](/blog/tag/drupal)
+  - [Drupal Feeds](/blog/tag/drupal)
+  - [Responsive design](/blog/tag/front-end-dev/)
+  - [jQuery](/blog/tag/javascript)
 client_logo: "/assets/img/work/transaction-advisors-case-study/transaction_advisors_logo.jpg"
 client_hero_image: "/assets/img/work/transaction-advisors-case-study/transaction_advisors_hero.jpg"
 project_objective_image: "/work/transaction-advisors-case-study/transaction_advisors_objective.jpg"

--- a/_case-studies/transaction-advisors-case-study.md
+++ b/_case-studies/transaction-advisors-case-study.md
@@ -19,10 +19,10 @@ project_process: |
 project_results: |
   Thanks to an agile approach in which we worked closely with our client, the new sites launched in time for an important conference, the administrative burden from running three separate websites was reduced, and both the customers and the business felt the benefit of easy to manage subscriptions.
 services_provided: |
-  - [Web design](/services#design)
+  - [Web design](/services#design-ux)
   - [Drupal theme development](/blog/tag/theming/)
   - [Drupal custom module development](/services#development)
-  - [Multisite](/services#drupal)
+  - [Drupal multisite](/services#development)
   - [Payment processing](/services#integrations)
   - [Migration](/services#migration)
 technologies_used: |


### PR DESCRIPTION
@chrisarusso This updates the services and technologies used links for all case studies.

For the most part, services link to services (with a few exceptions) and technologies used link to tags. A couple of things:

- I've linked the services to the anchor for that service on /services, but we may want to think about adding a page for each service and sub-service eventually.
- Do you have any updates to the links? There were a few I wasn't sure about, which I will link to on those particular lines in the diff.

