### PR TITLE
Issue #2562: Update Comment server URL and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ To add a new tag, complete the following:
 2. Add a new markdown file for the tag in blog/tag. This creates a page for posts with that tag.
 3. Add the tag to the front matter of your post.
 
+### Comments
+
+Comments are handled by a Dockerized instance of [Squabble](https://github.com/savaslabs/squabble). Please refer to that repositories README for notes on usage, and to the [wiki page](https://pm.savaslabs.com/projects/savaslabs/wiki/Squabble) for production deployment information.
+
 ### Staging site
 
 We have a password protected [staging site](http://blabs.savasdev.com)!

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -61,7 +61,7 @@ $(document).ready(
     function () {
 
         // Create variable for request URI.
-        var commentServer = "http://comments.savaslabs.com";
+        var commentServer = "http://comments.savaslabs.io:51062";
         var postSlug = window.location.pathname;
 
         // Remove leading forward slash.
@@ -82,7 +82,7 @@ $(document).ready(
 // COMMENT COUNT ON CARDS.
 $(document).ready(
     function () {
-        var commentServer = "http://comments.savaslabs.com";
+        var commentServer = "http://comments.savaslabs.io:51062";
         var requri = commentServer + '/api/comments/count';
         $.getJSON(
             requri, function (json) {
@@ -112,7 +112,7 @@ function enableCommentForm($id) {
     }
 
     // Create variable for request URI.
-    var commentServer = "http://comments.savaslabs.com";
+    var commentServer = "http://comments.savaslabs.io:51062";
     var postSlug = window.location.pathname;
 
     // Remove leading forward slash.

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,2 +1,2 @@
-comment_server_url: http://localhost:8000
+comment_server_url: "http://localhost:8000"
 comment_server_enabled: 1

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: >
 # not used at all.
 baseurl: ""
 url: "http://savaslabs.com"
-comment_server_url: http://comments.savaslabs.com
+comment_server_url: "http://comments.savaslabs.io:51062"
 comment_server_enabled: 1
 
 # Professional and social media links

--- a/_posts/2015-08-04-user-revision-sanitize.md
+++ b/_posts/2015-08-04-user-revision-sanitize.md
@@ -99,7 +99,7 @@ to ensure that the code I wrote would apply to most recent drush development.
 ### Getting breakpoints in PHPStorm to listen to drush
 Several have blogged about this before, so I'll just point theirs out. Generally,
 I followed
-[these instructions](https://www.deeson.co.uk/labs/debugging-drupal-drush-real-time-phpstorm-and-xdebug),
+[these instructions](https://webcache.googleusercontent.com/search?q=cache:qUjfZ093WwgJ:https://www.deeson.co.uk/labs/debugging-drupal-drush-real-time-phpstorm-and-xdebug+&cd=1&hl=en&ct=clnk&gl=us),
 but I trust that my mentor and friend
 Randy Fay['s article](http://randyfay.com/content/remote-command-line-debugging-phpstorm-phpdrupal-including-drush)
 is excellent as well. They all seemed to use


### PR DESCRIPTION
@AnneTee this PR switches the comments URL to a new instance of Squabble running on our Rancher infrastructure.

I've also updated the `main.js` file to reference the new URL.

/cc @timstallmann 