### PR TITLE
Issue #2559: Update github icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
     <ul>
       <li><h3>Around the Web</h3></li>
       <ul>
-        <li><a href="https://github.com/savaslabs"><span class="mega-octicon octicon-mark-github"></span></a></li>
+        <li><a href="https://github.com/savaslabs"><span class="fa fa-github fa-lg fa-2x"></span></a></li>
         <li><a href="https://www.drupal.org/node/2466865"><i class="fa fa-drupal fa-lg fa-2x"></i></a></li>
         <li><a href="https://twitter.com/savas_labs"><i class="fa fa-twitter fa-lg fa-2x"></i></a></li>
         <li><a href="https://www.linkedin.com/company/savas-labs"><i class="fa fa-linkedin fa-lg fa-2x"></i></a></li>

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -12,7 +12,7 @@ layout: default
         <li><i class="fa fa-drupal"></i><a href="https://www.drupal.org/u/{{ page.drupal }}">&nbsp;&nbsp;Drupal</a></li>
       {% endif %}
       {% if page.github %}
-        <li><span class="octicon octicon-mark-github"></span><a href="https://github.com/{{ page.github }}">&nbsp;&nbsp;Github</a></li>
+        <li><span class="fa fa-github"></span><a href="https://github.com/{{ page.github }}">&nbsp;&nbsp;Github</a></li>
       {% endif %}
       {% if page.twitter %}
         <li><i class="fa fa-twitter"></i><a href="https://twitter.com/{{ page.twitter }}">&nbsp;&nbsp;Twitter</a></li>

--- a/_posts/2015-08-04-user-revision-sanitize.md
+++ b/_posts/2015-08-04-user-revision-sanitize.md
@@ -99,7 +99,7 @@ to ensure that the code I wrote would apply to most recent drush development.
 ### Getting breakpoints in PHPStorm to listen to drush
 Several have blogged about this before, so I'll just point theirs out. Generally,
 I followed
-[these instructions](https://webcache.googleusercontent.com/search?q=cache:qUjfZ093WwgJ:https://www.deeson.co.uk/labs/debugging-drupal-drush-real-time-phpstorm-and-xdebug+&cd=1&hl=en&ct=clnk&gl=us),
+[these instructions](https://web.archive.org/web/20150405094739/https://www.deeson.co.uk/labs/debugging-drupal-drush-real-time-phpstorm-and-xdebug),
 but I trust that my mentor and friend
 Randy Fay['s article](http://randyfay.com/content/remote-command-line-debugging-phpstorm-phpdrupal-including-drush)
 is excellent as well. They all seemed to use


### PR DESCRIPTION
@lrowang This is a quick fix to change out the icons we were using for Github on team pages and in the footer. We were using an icon set called Octicons, which I deleted, but I missed a couple of instances where we were still trying to use them! I've replaced the old Github octicon with a font awesome icon.

---

Please pull this, build the site, and check out the center of the footer, which should look like this (Github icon is missing on the live site):

<img width="239" alt="screen shot 2016-12-12 at 3 54 27 pm" src="https://cloud.githubusercontent.com/assets/8465998/21116401/722d8180-c083-11e6-880b-eb96ab8407bd.png">

---

...and the team pages, which should have an icon next to the "Github" link:

<img width="439" alt="screen shot 2016-12-12 at 3 56 43 pm" src="https://cloud.githubusercontent.com/assets/8465998/21116448/9c9cce26-c083-11e6-9e52-37475bcc151e.png">

---

Thanks! 🍊 🍒 🍋 🍎 

