### PR TITLE
Issue #2566: Remove redundant "Get in Touch"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,11 @@
       </div>
     </div>
 
-    {% include contact.html %}
+    {% comment %} If on "/contact" page, don't display the redundant "contact us" block {% endcomment %}
+    {% if page.permalink != "/contact/" %}
+      {% include contact.html %}
+    {% endif %}
+
     {% include footer.html %}
     {% include scripts.html %}
 


### PR DESCRIPTION
Hi @oksana-c (cc @AnneTee)-

Would you mind reviewing this PR to make sure that the "Get in Touch" block has been correctly removed? 

- It should no longer show up on `/contact` **(Pic1)** but should still be displayed on all the other pages.
- Also, @AnneTee and I decided to leave the text in the body under the header "Contact" -- since it still seems nice to have a message there. We figured as long as the button no longer reloads the same page that'd be good!

**Pic1**
![contact](https://cloud.githubusercontent.com/assets/19154706/21199444/6a6864a8-c1f8-11e6-94b8-c2874ca7226c.png)