### PR TITLE
Issue #2584: fix contact page layout on small screens

### DIFF
--- a/_assets/styles/scss/base/_tables.scss
+++ b/_assets/styles/scss/base/_tables.scss
@@ -61,3 +61,22 @@
     }
   }
 }
+
+// Contact page table.
+.table-minimal--contact {
+  p {
+    display: none;
+
+    @include media(em(450)) {
+      display: inline;
+    }
+  }
+
+  .table-minimal--contact__label {
+    width: 30%;
+
+    @include media(em(450)) {
+      width: 50%;
+    }
+  }
+}

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -4,47 +4,47 @@ title: Contact
 permalink: "/contact/"
 excerpt: All the ways to contact Savas Labs
 ---
-<!-- TODO: make page descriptions consistent -->
+{% comment %} @TODO: make page descriptions consistent. {% endcomment %}
 <p style="text-align: center;">If you're interested to work with us on a project, get in touch!</p>
-<table class="table-minimal">
+<table class="table-minimal table-minimal--contact">
   <tbody>
     <tr>
-      <td>
+      <td class="table-minimal--contact__label">
         <span class="fa-stack fa-lg">
           <i class="fa fa-circle fa-stack-2x"></i>
           <i class="fa fa-envelope-o fa-stack-1x fa-inverse"></i>
         </span>
-        &nbsp;&nbsp;Email
+        <p>&nbsp;&nbsp;Email</p>
       </td>
       <td><a href="mailto:info@savaslabs.com">info@savaslabs.com</a></td>
     </tr>
     <tr>
-      <td>
+      <td class="table-minimal--contact__label">
         <span class="fa-stack fa-lg">
           <i class="fa fa-circle fa-stack-2x"></i>
           <i class="fa fa-phone fa-stack-1x fa-inverse"></i>
         </span>
-        &nbsp;&nbsp;Phone
+        <p>&nbsp;&nbsp;Phone</p>
       </td>
       <td>(919) 432-4660</td>
     </tr>
     <tr>
-      <td>
+      <td class="table-minimal--contact__label">
         <span class="fa-stack fa-lg">
           <i class="fa fa-circle fa-stack-2x"></i>
           <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
         </span>
-        &nbsp;&nbsp;Twitter
+        <p>&nbsp;&nbsp;Twitter</p>
       </td>
       <td><a href="https://twitter.com/savas_labs">@savas_labs</a></td>
     </tr>
     <tr>
-      <td>
+      <td class="table-minimal--contact__label">
         <span class="fa-stack fa-lg">
           <i class="fa fa-circle fa-stack-2x"></i>
           <i class="fa fa-building-o fa-stack-1x fa-inverse"></i>
         </span>
-        &nbsp;&nbsp;Durham office
+        <p>&nbsp;&nbsp;Durham office</p>
       </td>
       <td>Savas Labs<br>
           PMB 210<br>

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -7,38 +7,50 @@ excerpt: All the ways to contact Savas Labs
 <!-- TODO: make page descriptions consistent -->
 <p style="text-align: center;">If you're interested to work with us on a project, get in touch!</p>
 <table class="table-minimal">
-    <tbody>
-        <tr>
-            <td><span class="fa-stack fa-lg">
-  <i class="fa fa-circle fa-stack-2x"></i>
-  <i class="fa fa-envelope-o fa-stack-1x fa-inverse"></i>
-            </span>&nbsp;&nbsp;Email</td>
-            <td><a href="mailto:info@savaslabs.com">info@savaslabs.com</a></td>
-        </tr>
-        <tr>
-            <td><span class="fa-stack fa-lg">
-            <i class="fa fa-circle fa-stack-2x"></i>
-            <i class="fa fa-phone fa-stack-1x fa-inverse"></i>
-            </span>&nbsp;&nbsp;Phone</td>
-            <td>(919) 432-4660</td>
-        </tr>
-        <tr>
-            <td><span class="fa-stack fa-lg">
-            <i class="fa fa-circle fa-stack-2x"></i>
-            <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
-            </span>&nbsp;&nbsp;Twitter</td>
-            <td><a href="https://twitter.com/savas_labs">@savas_labs</a></td>
-        </tr>
-        <tr>
-            <td><span class="fa-stack fa-lg">
-            <i class="fa fa-circle fa-stack-2x"></i>
-            <i class="fa fa-building-o fa-stack-1x fa-inverse"></i>
-            </span>&nbsp;&nbsp;Durham office</td>
-
-            <td>Savas Labs<br />
-                PMB 210<br />
-                201 W Main Street, Suite 100<br />
-                Durham, NC 27701<br /></td>
-        </tr>
-    </tbody>
+  <tbody>
+    <tr>
+      <td>
+        <span class="fa-stack fa-lg">
+          <i class="fa fa-circle fa-stack-2x"></i>
+          <i class="fa fa-envelope-o fa-stack-1x fa-inverse"></i>
+        </span>
+        &nbsp;&nbsp;Email
+      </td>
+      <td><a href="mailto:info@savaslabs.com">info@savaslabs.com</a></td>
+    </tr>
+    <tr>
+      <td>
+        <span class="fa-stack fa-lg">
+          <i class="fa fa-circle fa-stack-2x"></i>
+          <i class="fa fa-phone fa-stack-1x fa-inverse"></i>
+        </span>
+        &nbsp;&nbsp;Phone
+      </td>
+      <td>(919) 432-4660</td>
+    </tr>
+    <tr>
+      <td>
+        <span class="fa-stack fa-lg">
+          <i class="fa fa-circle fa-stack-2x"></i>
+          <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
+        </span>
+        &nbsp;&nbsp;Twitter
+      </td>
+      <td><a href="https://twitter.com/savas_labs">@savas_labs</a></td>
+    </tr>
+    <tr>
+      <td>
+        <span class="fa-stack fa-lg">
+          <i class="fa fa-circle fa-stack-2x"></i>
+          <i class="fa fa-building-o fa-stack-1x fa-inverse"></i>
+        </span>
+        &nbsp;&nbsp;Durham office
+      </td>
+      <td>Savas Labs<br>
+          PMB 210<br>
+          201 W Main Street, Suite 100<br>
+          Durham, NC 27701<br>
+      </td>
+    </tr>
+  </tbody>
 </table>


### PR DESCRIPTION
Hey @lrowang, this fixes the text on the contact page that's running over the edge of the screen:

![img_2700](https://cloud.githubusercontent.com/assets/8465998/21401267/ab91d386-c781-11e6-9a8c-7d842b170d5d.PNG)

To test, pull this branch, run `gulp serve`, and check out the contact page on multiple screen widths.

Note: I noticed a weird (BrowserSync?) bug where if I open up the inspector and click the mobile view button, the CSS doesn't adjust quite right. You can overcome this by navigating to a different page, then back to the page you want to look at.