### PR TITLE
Issue #2520: Include case study and blog post templates

### DIFF
--- a/_templates/blog-post.md
+++ b/_templates/blog-post.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: # Enter title in quotes
+date: # e.g. 2016-11-15
+author: # Enter the author name
+tags: # Enter tags separated by spaces
+summary: # Enter a one-sentence summary
+featured_image: "/blog/[path to image]"
+featured_image_alt: # Enter alt text in quotes
+featured_image_height: "000px"
+featured_image_width: "1474px"
+drupal_planet_summary: |
+  # Include this if this post has the Drupal tag
+---
+
+## Headings
+
+Your post title (stored in the post's front matter) will be an H1. Your
+top-level headings should be H2's (##), then H3's (###), etc.
+
+## Images
+
+You can include a featured image in the front matter using the `featured_image`
+and `featured_image_alt` keys. This will work for our site and for Drupal Planet.
+Please try to do this for every post!
+
+Your image should be 1474px wide. Blog images should be placed in
+`_/assets/img/blog`, but you should only include `/blog/[filename].jpg` in the
+front matter of your post.
+
+Lastly, please include `featured_image_width` and `featured_image_height` in
+pixels to satisfy Google's structured data requirements.
+
+## Syntax Highlighting
+
+Since updating to Jekyll 3.0.2 which uses Kramdown/Rouge, to use syntax
+highlighting in a post you just need to use backticks (similar to GitHub or
+Slack highlighting).
+
+Special tips:
+
+1. You can include the language name after the first set of backticks with no
+space e.g. ```bash
+2. The syntax block must be proceeded and followed by blank lines.
+3. For php you must including an opening php tag to get proper highlighting.
+4. To display raw Liquid code, you'll need to wrap your code in {% raw %} and
+{% endraw %} tags.
+
+## Tags
+
+To add a new tag, complete the following:
+
+1. Add the tag to _data/tags.yml.
+2. Add a new markdown file for the tag in blog/tag. This creates a page for posts with that tag.
+3. Add the tag to the front matter of your post.

--- a/_templates/case-study.md
+++ b/_templates/case-study.md
@@ -1,0 +1,156 @@
+---
+layout: case-study
+featured: # Enter 1 to feature on the front page, otherwise 0.
+weight: # Enter a negative number to place at the top of the list.
+tags: # See _data/tags.yml for a list of tags or the README for instructions on adding a new one
+project_title: # Enter the project title.
+client_name: # Enter the client name.
+client_url: # Enter the URL in quotation marks.
+client_description: |
+  # Enter a one-sentence client description here.
+client_dates: # e.g. 2016 - present
+client_quote: |
+   # Enter the quote here.
+client_quote_author: |
+  # Enter the name and title here.
+project_highlights: # e.g. [Content migration, Custom module development, User experience enhancement, Dockerized deployment]
+project_description: |
+  # Enter the project description here.
+project_objective: |
+  # Enter the project objective here.
+project_process: |
+  # Enter the project process here.
+project_results: |
+  # Enter the project results here.
+services_provided: |
+  - # Enter a bulleted list of services that link to the services page.
+technologies_used: |
+  - # Enter a bulleted list of technologies used that link to tag pages.
+client_logo: "/assets/img/work/[path to logo]"
+client_logo_width: "000px"
+client_logo_height: "00px"
+client_hero_image: "/assets/img/work/[path to image]"
+project_objective_image: "/work/[path to image]"
+project_objective_image_alt: "Alt text"
+project_process_image: "/work/[path to image]"
+project_process_image_alt: "Alt text"
+project_results_image: "/work/[path to image]"
+project_results_image_alt: "Alt text"
+---
+
+Note: If this is not a premier case study, all text below the --- above should
+be deleted.
+
+## Narrative outline
+
+Below are potential topics for discussion for the long-form narrative for
+premier case studies. You will probably not want to include all of them,
+perhaps the 3-4 most relevant.
+
+### Discussion of project goals, management, and workflow
+
+Discuss the project goals more in depth and include how the goals were formed
+with the client, how the goals were to be measured from beginning to end, and
+how Savas Labs worked with the client to meet those goals. Describe how the
+project was run from a PM standpoint and how SL was able to guide the client
+through the process with transparency and expertise. Review how SL works and
+how our methodology applied to this project specifically.
+
+### Discussion of design process and user experience consulting
+
+Here we can highlight our design process and describe how we worked with the
+client to capture their needs within the design. We can highlight modern tools
+and design paradigms used in the process. We can also discuss UX design and
+describe our process and its benefits.
+
+### Discussion of audit process
+
+If we performed an audit, we can talk about the process and the audit findings.
+We can highlight how the audit provided us with information used to accurately
+predict the remaining work to be done, projected hours, and timeline. This is
+a good opportunity to highlight the benefits of a thorough audit.
+
+### Discussion of technologies used
+
+Here we can go into detail of the specific work done on the project. This
+could include:
+
+- Custom modules developed
+- Custom theming
+- Information architecture
+- Migration
+- Third party integration
+- Performance improvements
+- Commerce integration
+
+### Highlighting specific features improved
+
+If there are specific features we created or improved, we can describe the
+process and results here. This is a great place to include screenshots.
+
+### Demonstrate benefit received by the client
+
+If we captured metrics such as performance profiling, Google analytics, etc.
+we can share them here. We can also discuss less tangible results, such as
+client satisfaction, improved user experience, improved design, better
+adherence to modern design or accessibility standards, etc.
+
+### Discuss positive outcomes for the company
+
+If we have positive outcomes on our end from the project, we can highlight them
+here. Some examples would be a positive experience with a new technology that we
+look forward to using with other clients, working on a project that we believe
+does good in the world, or successfully employing a project management workflow.
+This is something often not included on other agencies' sites, but it fits
+with our personable, honest brand. Note that this isn't a place to say that we
+messed up and learned from it, or that we filled a gap in our knowledge. We want
+this to reflect well on the company!
+
+---
+
+## Image ideas
+
+Below are some ideas for images to be included, sorted into various categories.
+
+### Photography
+
+- A photograph from the website, used with permission
+- A photograph of the site being viewed on a device
+
+### Screenshots
+
+- A screenshot of a page, especially on a variety of devices
+- A comparison of the site before and after a redesign
+- A screenshot of a small, beautiful detail of the site (icons, a menu, a form, etc.)
+- A screenshot showing the way a user would interact with the site
+
+### Design
+
+- A photograph of a sketch or diagram drawn during the design phase
+- Wireframes used during design
+- Part of a styleguide, mood board, or style tiles
+
+### Information architecture
+
+- A photograph of diagrams or brainstorming notes
+- A screenshot or image of a diagram, flowchart, etc.
+- A screenshot of stubbed out, heavily commented code
+
+### Module development
+
+- A screenshot of the results from the front end of the site
+- A screenshot of functionality or customizations added to the Drupal admin UI
+- A screenshot demonstrating the ease of use of the admin interface
+- A screenshot of code
+- A photograph of a screen showing code (possibly blurry so actual code isn't clear)
+
+### Consulting and project management
+
+- A photograph fo the team consulting with the client (staged or real)
+- A photograph of the team working together on the project
+
+### Logos and iconography
+
+- The client's logo, displayed artistically
+- A logo from software we used on the project
+- A sampling of icons we used on the site


### PR DESCRIPTION
@chrisarusso I've created two templates in the new `_templates` directory:

- A blog post template, with instructions in the front matter and some instructions taken from the README in the body
- A case study template, with instructions in the front matter and some ideas for a longer narrative in the body for premier case studies

Please let me know if you have any further ideas for the narrative, or changes to what I've got there. Once we're in agreement I can start writing the narratives for HPTN and PMP 🗺 