### PR TITLE
Issue #2614: Retrieve comments via GET request

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -118,15 +118,12 @@ function enableCommentForm($id) {
     // Remove leading forward slash.
     var truncatedSlug = postSlug.substring(1, postSlug.length);
     var encodedSlug = encodeURIComponent(truncatedSlug);
-    var requri = commentServer + '/api/comments/post';
-    var payload = {};
-    payload.slug = encodedSlug;
+    var requri = commentServer + '/api/comments/post?slug=' + encodedSlug;
     $.ajax(
         {
             url: requri,
-            type: 'POST',
+            type: 'GET',
             dataType: 'json',
-            data: payload,
             success: function (json) {
                 var outhtml = '';
 


### PR DESCRIPTION
This PR needs to be merged after https://github.com/savaslabs/squabble/pull/17 is merged and deployed to production. It switches the JS to load comments per post via a GET request. You'll want to use this branch while testing out improving the error messages shown to users on failed comment submissions.