### PR TITLE
Issue #2533: improve comment error message

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -214,9 +214,15 @@ function enableCommentForm($id) {
                         $('#post-comments').append(item);
                     },
                     error: function (e) {
+
+                        // Re-enable the submit button.
                         submit.val('Submit').removeAttr('disabled');
+
+                        // Display the error.
                         $('#comment-form').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
-                        var errorField = e.responseJSON.error_field;
+
+                        // Highlight the erroneous field.
+                        var errorField = e.responseJSON.data.error_field;
                         if (errorField) {
                           $('.' + errorField).addClass('error-field');
                         }

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -215,7 +215,11 @@ function enableCommentForm($id) {
                     },
                     error: function (e) {
                         submit.val('Submit').removeAttr('disabled');
-                        $('#post-comments').prepend('<div class="flash-error">' + 'We couldn\'t post your comment, sorry!' + '<br>' + 'Please make sure all fields are filled out or try again later.' + '</div>');
+                        $('#post-comments').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
+                        var errorField = e.responseJSON.error_field;
+                        if (errorField) {
+                          $('.' + errorField).addClass('error');
+                        }
                     }
                 });
         });

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -215,10 +215,10 @@ function enableCommentForm($id) {
                     },
                     error: function (e) {
                         submit.val('Submit').removeAttr('disabled');
-                        $('#post-comments').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
+                        $('#comment-form').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
                         var errorField = e.responseJSON.error_field;
                         if (errorField) {
-                          $('.' + errorField).addClass('error');
+                          $('.' + errorField).addClass('error-field');
                         }
                     }
                 });

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -96,6 +96,11 @@
     }
   }
 
+  .error {
+    border-color: $fuschia;
+    border-width: 3px;
+  }
+
   // Hide honeypot field.
   // scss-lint:disable IdSelector
   #url {

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -96,9 +96,13 @@
     }
   }
 
-  .error {
+  .error-field {
     border-color: $fuschia;
     border-width: 3px;
+  }
+
+  .flash-error {
+    margin-top: $base-spacing;
   }
 
   // Hide honeypot field.


### PR DESCRIPTION
@kostajh This uses the error message from Squabble specific to the erroneous field, displays it, and styles the erroneous field to draw the user's eye to it. I also moved the error message to just above the comment form - it was displaying above all the existing comments before.

Let me know if you think there's a better way to do any of this. I want to improve the nocaptcha field overall soon anyway!

This shouldn't be merged until [this PR for squabble](https://github.com/savaslabs/squabble/pull/18) and [this PR for savaslabs.com](https://github.com/savaslabs/savaslabs.github.io/pull/209).

Thanks for your help on this!