### PR TITLE
Issue #2660: improve comment form

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -129,7 +129,7 @@ function enableCommentForm($id) {
 
                 // If there are comments, include a link to the comment form.
                 if (json.data.length > 0) {
-                    outhtml = '<p class="comment-form-link"><a href="#comment-form">Leave a comment</a></p>'
+                    outhtml = '<p class="comment-form-link" id="comment-form-link"><a href="#comment-form">Leave a comment</a></p>'
                 }
 
                 // Loop through comments.
@@ -180,7 +180,7 @@ function enableCommentForm($id) {
                     beforeSend: function () {
 
                         // Change submit button value text and disable it.
-                        // submit.val('Submitting...').attr('disabled', 'disabled');
+                        submit.val('Submitting...').attr('disabled', 'disabled');
                         $('.flash-error').remove();
                         $('.flash-success').remove();
                     },
@@ -199,9 +199,11 @@ function enableCommentForm($id) {
 
                         // Create HTML output.
                         var thanks = '<div class="flash-success">Thanks for submitting your comment!</div>';
-                        $('#post-comments').prepend(thanks);
+                        $('#post-comments').append(thanks);
+                        $('.flash-success').delay(10000).fadeOut();
                         form.trigger('reset');
                         form.hide();
+                        submit.val('Post comment').removeAttr('disabled');
 
                         // Append new comment.
                         var outhtml = '';
@@ -212,6 +214,12 @@ function enableCommentForm($id) {
                         // Append with fadeIn, see http://stackoverflow.com/a/978731
                         var item = $(outhtml).hide().fadeIn(800);
                         $('#post-comments').append(item);
+
+                        // Comment form is hidden but should show if user clicks
+                        // the link.
+                        $('#comment-form-link').click(function () {
+                            form.show();
+                        });
                     },
                     error: function (e) {
 

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -226,7 +226,7 @@ function enableCommentForm($id) {
                         // Re-enable the submit button.
                         submit.val('Post comment').removeAttr('disabled');
 
-                        // Highlight the erroneous field. and display the error.
+                        // Highlight the erroneous field and display the error.
                         var errorField = '#' + e.responseJSON.data.error_field;
                         if (errorField) {
                           $(errorField).addClass('error-field');

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -227,10 +227,15 @@ function enableCommentForm($id) {
                         submit.val('Post comment').removeAttr('disabled');
 
                         // Highlight the erroneous field. and display the error.
-                        var errorField = '.' + e.responseJSON.data.error_field;
+                        var errorField = '#' + e.responseJSON.data.error_field;
                         if (errorField) {
                           $(errorField).addClass('error-field');
                           $(errorField).parent().prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
+
+                          // If the user clicks submit again, remove the error highlighting.
+                          submit.click(function () {
+                            $(errorField).removeClass('error-field');
+                          });
                         }
                         else {
                           $('#comment-form').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -216,15 +216,16 @@ function enableCommentForm($id) {
                     error: function (e) {
 
                         // Re-enable the submit button.
-                        submit.val('Submit').removeAttr('disabled');
+                        submit.val('Post comment').removeAttr('disabled');
 
-                        // Display the error.
-                        $('#comment-form').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
-
-                        // Highlight the erroneous field.
-                        var errorField = e.responseJSON.data.error_field;
+                        // Highlight the erroneous field. and display the error.
+                        var errorField = '.' + e.responseJSON.data.error_field;
                         if (errorField) {
-                          $('.' + errorField).addClass('error-field');
+                          $(errorField).addClass('error-field');
+                          $(errorField).parent().prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
+                        }
+                        else {
+                          $('#comment-form').prepend('<div class="flash-error">' + e.responseJSON.message  + '</div>');
                         }
                     }
                 });

--- a/_assets/styles/scss/base/_typography.scss
+++ b/_assets/styles/scss/base/_typography.scss
@@ -145,3 +145,7 @@ blockquote {
     margin-bottom: 0;
   }
 }
+
+label {
+  font-family: $copytext-font;
+}

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -40,69 +40,40 @@
 // Comments.
 .post-comments {
 
-  // Comment form.
-  // Make name and email inline on larger screens.
-  @include media($medium-screen-up) {
-    .comment-name,
-    .comment-email {
-      display: inline-block;
-      width: 48%;
+  // General form field styles.
+  .comment-form__field {
+    margin-bottom: 1.5em;
+
+    &__label {
+      font-weight: bold;
+      margin: 0;
     }
 
-    .comment-name { float: left; }
-    .comment-email { float: right; }
-  }
-
-  p {
-    margin: 0;
-  }
-
-  textarea {
-    margin-bottom: 0;
-  }
-
-  .email-disclaimer {
-    font-size: .8em;
-    margin-top: -1em;
-  }
-
-  .hint {
-    font-size: .8em;
-  }
-
-  .below-textarea {
-    margin-top: -.5em;
-  }
-
-  .nocaptcha {
-    margin-bottom: 0;
-  }
-
-  .are-you-human {
-    @include span-columns(12);
-    margin-top: 2em;
-  }
-
-  .are-you-human-field {
-    @include span-columns(9);
-  }
-
-  .are-you-human-owl {
-    @include span-columns(3);
-    text-align: center;
-
-    img {
-      width: 4em;
+    p,
+    input,
+    textarea {
+      margin-bottom: 0;
     }
   }
 
-  .error-field {
-    border-color: $fuschia;
-    border-width: 3px;
+  // Text inputs.
+  .comment-form__field--name,
+  .comment-form__field--email {
+    max-width: 375px;
   }
 
-  .flash-error {
-    margin-top: $base-spacing;
+  .comment-form__field--comment {
+    max-width: 600px;
+
+    // This removes extra space under textarea in some browsers.
+    textarea {
+      vertical-align: top;
+    }
+  }
+
+  // Helptext below fields.
+  .comment-form__field__helptext {
+    font-size: .8em;
   }
 
   // Hide honeypot field.
@@ -112,8 +83,43 @@
   }
   // scss-lint:enable IdSelector
 
-  .submit-comment {
+  // Nocaptcha field.
+  .comment-form__field--nocaptcha {
+    @include span-columns(12);
+
+    &__image {
+      @include span-columns(3);
+      text-align: center;
+
+      img {
+        width: 4em;
+      }
+    }
+
+    &__input {
+      @include span-columns(9);
+
+      input {
+        width: 100px;
+      }
+    }
+  }
+
+  // Submit button.
+  .comment-form__submit {
     @extend %button;
+    margin-top: 0;
+  }
+
+  // Style the error message at the top of the comment form.
+  .flash-error {
+    margin-top: $base-spacing;
+  }
+
+  // Highlight field indicated in an error response.
+  .error-field {
+    border-color: $fuschia;
+    border-width: 3px;
   }
 
   // Existing comments.

--- a/_assets/styles/scss/components/_comments.scss
+++ b/_assets/styles/scss/components/_comments.scss
@@ -111,6 +111,11 @@
     margin-top: 0;
   }
 
+  // Style the success message above the new comment.
+  .flash-success {
+    margin-top: 1.5em;
+  }
+
   // Style the error message at the top of the comment form.
   .flash-error {
     margin-top: $base-spacing;

--- a/_includes/comment-form.html
+++ b/_includes/comment-form.html
@@ -1,46 +1,57 @@
 <div class="post-comments">
+
   {% if page.comments_enabled == 0 %}
     <p>Comments are disabled for this post.</p>
+
   {% else %}
     <div class="expander">
       <a href="javascript:void(0)" id="js-expander-trigger" class="expander-trigger expander-hidden">Comments!</a>
+
       <div id="js-expander-content" class="expander-content">
+
         <!-- If there are existing comments, output them here. -->
         <div id="post-comments" class="post-comments"></div>
+
         <!-- New comment form -->
-        <form id="comment-form">
+        <form id="comment-form" class="comment-form">
           <h4>Leave a comment</h4>
-          <div class="comment-name">
-            <p>Name</p> <input type='text' name='name' id='name' required /><br>
+
+          <div class="comment-form__field comment-form__field--name">
+            <label class="comment-form__field__label" for="name">Name</label>
+            <input type="text" name="name" id="name" required>
           </div>
 
-          <div class="comment-email">
-            <p>Email</p> <input type='email' name='email' id='email' required />
-            <p class="email-disclaimer">Savas Labs will never sell your email address or spam you.</p><br>
+          <div class="comment-form__field comment-form__field--email">
+            <label class="comment-form__field__label" for="email">Email</label>
+            <input type="email" name="email" id="email" required>
+            <p class="comment-form__field__helptext">Savas Labs will never sell your email address or spam you.</p>
           </div>
 
-          <p>Comment</p>
-          <textarea name='comment' id='comment' required></textarea>
-          <p class="hint below-textarea">Plain text format only please.</p>
+          <div class="comment-form__field comment-form__field--comment">
+            <label class="comment-form__field__label" for="comment">Comment</label>
+            <textarea name="comment" id="comment" required></textarea>
+            <p class="comment-form__field__helptext">Plain text format only please.</p>
+          </div>
 
-          <input type='hidden' name='slug' id='slug' value='{{ page.url }}' />
-          <input type='text' name='url' id='url' />
+          <input type="hidden" name="slug" id="slug" value="{{ page.url }}">
+          <input type="text" name="url" id="url">
 
-          <div class='are-you-human'>
-            <div class='are-you-human-owl'>
+          <div class="comment-form__field comment-form__field--nocaptcha">
+            <div class="comment-form__field--nocaptcha__image">
               <img src="/assets/img/icons-and-logos/owl.png" alt="Savas Labs logo">
             </div>
-            <div class='are-you-human-field'>
-              <p>What type of animal is the Savas Labs logo?</p>
-              <input type='text' name='nocaptcha' id='nocaptcha' class='nocaptcha'>
-              <p class="hint">Hint: 3 letters long, starts with an 'o' and ends with an 'l'.</p>
+            <div class="comment-form__field--nocaptcha__input">
+              <label class="comment-form__field__label" for="nocaptcha">What type of animal is the Savas Labs logo?</label>
+              <p class="comment-form__field__helptext">Hint: 3 letters long, starts with an "o" and ends with an "l".</p>
+              <input type="text" name="nocaptcha" id="nocaptcha" class="nocaptcha">
             </div>
           </div>
 
-          <input type='submit' value='Submit' id='submit' class="submit-comment"/>
+          <input type="submit" value="Post comment" id="submit" class="comment-form__submit">
         </form>
-      </div>
-    </div>
+
+      </div><!-- comments and comment form -->
+    </div><!-- expander -->
   {% endif %}
   <hr>
 </div>

--- a/_includes/comment-form.html
+++ b/_includes/comment-form.html
@@ -43,7 +43,7 @@
             <div class="comment-form__field--nocaptcha__input">
               <label class="comment-form__field__label" for="nocaptcha">What type of animal is the Savas Labs logo?</label>
               <p class="comment-form__field__helptext">Hint: 3 letters long, starts with an "o" and ends with an "l".</p>
-              <input type="text" name="nocaptcha" id="nocaptcha" class="nocaptcha">
+              <input type="text" name="nocaptcha" id="nocaptcha">
             </div>
           </div>
 

--- a/_includes/comment-form.html
+++ b/_includes/comment-form.html
@@ -43,7 +43,7 @@
             <div class="comment-form__field--nocaptcha__input">
               <label class="comment-form__field__label" for="nocaptcha">What type of animal is the Savas Labs logo?</label>
               <p class="comment-form__field__helptext">Hint: 3 letters long, starts with an "o" and ends with an "l".</p>
-              <input type="text" name="nocaptcha" id="nocaptcha">
+              <input type="text" name="nocaptcha" id="nocaptcha" required>
             </div>
           </div>
 

--- a/_posts/2016-05-26-installing-xhprof.md
+++ b/_posts/2016-05-26-installing-xhprof.md
@@ -25,7 +25,7 @@ If there's only one thing you take away from this blog post, let it be: read and
 
 ### Install XHProf in a VM
 
-If you're not running DrupalVM, you'll need to install XHProf manually via [PECL](https://pecl.php.net/). On [DrupalVM](http://docs.drupalvm.com/en/latest/), [XHProf is already installed](http://docs.drupalvm.com/en/latest/extras/profile-code/#xhprof) and you can skip to the next step.
+If you're not running DrupalVM, you'll need to install XHProf manually via [PECL](https://pecl.php.net/). On [DrupalVM](http://docs.drupalvm.com/en/latest/), XHProf is already installed and you can skip to the next step.
 
 `sudo pecl install xhprof-beta`
 


### PR DESCRIPTION
@kostajh This PR does the following:

- Improves the markup of the comment form to use `<label>` elements linked to their related inputs for accessibility purposes, to improve organization, to use BEM-style CSS classes, and to make the CTA ("Post comment") more descriptive
- Overhauls the SCSS for the comment form to improve consistency and organization and to ensure that:
  - Labels are clearly paired with their inputs
  - Text input width mirrors the length of expected responses
  - A one-column layout is used so fields aren't easily missed
  - Help text is more consistent across fields
- Updates the JS to:
  - Use the field-specific error message provided by the Squabble response, not the generic one
  - Add a CSS class to the field indicated in an error so that field can be highlighted visually. This class is removed on subsequent submits.
  - Show the error message directly above the erroneous field (may change this once we can handle multiple errors, but the most common error will be the nocaptcha field and it's hard to see the error message if it's at the top of the form)
  - Post the success message directly above the new comment rather than the top of the comment form. This becomes important when there are a lot of comments (more than 3-4).
  - On submit, changes the submit button text to "Submitting..."
  - Show the comment form if the user clicks the "Leave a comment" link

This will resolve [#2608](https://pm.savaslabs.com/issues/2608) and [#2661](https://pm.savaslabs.com/issues/2661), and improves the implementation of [#2553](https://pm.savaslabs.com/issues/2533) by extending the specific error messages to all fields for browsers like Safari that don't do inline validation of HTML5 forms.

To test, run Squabble locally [on this branch](https://github.com/savaslabs/squabble/pull/21) and try submitting the form with blank fields, especially in Safari. Also try submitting a complete comment, then click the "leave a comment" link.

This should be merged after [this Squabble branch](https://github.com/savaslabs/squabble/pull/21) is deployed.

Let me know if you have any suggestions!