### PR TITLE
Issue #2767: fix leaflet assets

### DIFF
--- a/_assets/styles/leaflet.css
+++ b/_assets/styles/leaflet.css
@@ -1,205 +1,259 @@
 /* required styles */
 
-.leaflet-map-pane,
+.leaflet-pane,
 .leaflet-tile,
 .leaflet-marker-icon,
 .leaflet-marker-shadow,
-.leaflet-tile-pane,
 .leaflet-tile-container,
-.leaflet-overlay-pane,
-.leaflet-shadow-pane,
-.leaflet-marker-pane,
-.leaflet-popup-pane,
-.leaflet-overlay-pane svg,
+.leaflet-pane > svg,
+.leaflet-pane > canvas,
 .leaflet-zoom-box,
 .leaflet-image-layer,
 .leaflet-layer {
 	position: absolute;
 	left: 0;
 	top: 0;
-	}
+}
 .leaflet-container {
 	overflow: hidden;
-	-ms-touch-action: none;
-	}
+}
 .leaflet-tile,
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
 	-webkit-user-select: none;
-	   -moz-user-select: none;
-	        user-select: none;
+	-moz-user-select: none;
+	user-select: none;
 	-webkit-user-drag: none;
-	}
+}
+/* Safari renders non-retina tile on retina better with this, but Chrome is worse */
+.leaflet-safari .leaflet-tile {
+	image-rendering: -webkit-optimize-contrast;
+}
+/* hack that prevents hw layers "stretching" when loading new tiles */
+.leaflet-safari .leaflet-tile-container {
+	width: 1600px;
+	height: 1600px;
+	-webkit-transform-origin: 0 0;
+}
 .leaflet-marker-icon,
 .leaflet-marker-shadow {
 	display: block;
-	}
-/* map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container img {
-	max-width: none !important;
-	}
-/* stupid Android 2 doesn't understand "max-width: none" properly */
+}
+/* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
+/* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
+.leaflet-container .leaflet-overlay-pane svg,
+.leaflet-container .leaflet-marker-pane img,
+.leaflet-container .leaflet-shadow-pane img,
+.leaflet-container .leaflet-tile-pane img,
 .leaflet-container img.leaflet-image-layer {
-	max-width: 15000px !important;
-	}
+	max-width: none !important;
+}
+
+.leaflet-container.leaflet-touch-zoom {
+	-ms-touch-action: pan-x pan-y;
+	touch-action: pan-x pan-y;
+}
+.leaflet-container.leaflet-touch-drag {
+	-ms-touch-action: pinch-zoom;
+}
+.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
+	-ms-touch-action: none;
+	touch-action: none;
+}
 .leaflet-tile {
 	filter: inherit;
 	visibility: hidden;
-	}
+}
 .leaflet-tile-loaded {
 	visibility: inherit;
-	}
+}
 .leaflet-zoom-box {
 	width: 0;
 	height: 0;
-	}
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	z-index: 800;
+}
 /* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
 .leaflet-overlay-pane svg {
 	-moz-user-select: none;
-	}
+}
 
-.leaflet-tile-pane    { z-index: 2; }
-.leaflet-objects-pane { z-index: 3; }
-.leaflet-overlay-pane { z-index: 4; }
-.leaflet-shadow-pane  { z-index: 5; }
-.leaflet-marker-pane  { z-index: 6; }
-.leaflet-popup-pane   { z-index: 7; }
+.leaflet-pane         { z-index: 400; }
+
+.leaflet-tile-pane    { z-index: 200; }
+.leaflet-overlay-pane { z-index: 400; }
+.leaflet-shadow-pane  { z-index: 500; }
+.leaflet-marker-pane  { z-index: 600; }
+.leaflet-tooltip-pane   { z-index: 650; }
+.leaflet-popup-pane   { z-index: 700; }
+
+.leaflet-map-pane canvas { z-index: 100; }
+.leaflet-map-pane svg    { z-index: 200; }
 
 .leaflet-vml-shape {
 	width: 1px;
 	height: 1px;
-	}
+}
 .lvml {
 	behavior: url(#default#VML);
 	display: inline-block;
 	position: absolute;
-	}
+}
 
 
 /* control positioning */
 
 .leaflet-control {
 	position: relative;
-	z-index: 7;
+	z-index: 800;
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
 	pointer-events: auto;
-	}
+}
 .leaflet-top,
 .leaflet-bottom {
 	position: absolute;
 	z-index: 1000;
 	pointer-events: none;
-	}
+}
 .leaflet-top {
 	top: 0;
-	}
+}
 .leaflet-right {
 	right: 0;
-	}
+}
 .leaflet-bottom {
 	bottom: 0;
-	}
+}
 .leaflet-left {
 	left: 0;
-	}
+}
 .leaflet-control {
 	float: left;
 	clear: both;
-	}
+}
 .leaflet-right .leaflet-control {
 	float: right;
-	}
+}
 .leaflet-top .leaflet-control {
 	margin-top: 10px;
-	}
+}
 .leaflet-bottom .leaflet-control {
 	margin-bottom: 10px;
-	}
+}
 .leaflet-left .leaflet-control {
 	margin-left: 10px;
-	}
+}
 .leaflet-right .leaflet-control {
 	margin-right: 10px;
-	}
+}
 
 
 /* zoom and fade animations */
 
-.leaflet-fade-anim .leaflet-tile,
+.leaflet-fade-anim .leaflet-tile {
+	will-change: opacity;
+}
 .leaflet-fade-anim .leaflet-popup {
 	opacity: 0;
 	-webkit-transition: opacity 0.2s linear;
-	   -moz-transition: opacity 0.2s linear;
-	     -o-transition: opacity 0.2s linear;
-	        transition: opacity 0.2s linear;
-	}
-.leaflet-fade-anim .leaflet-tile-loaded,
+	-moz-transition: opacity 0.2s linear;
+	-o-transition: opacity 0.2s linear;
+	transition: opacity 0.2s linear;
+}
 .leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
 	opacity: 1;
-	}
-
+}
+.leaflet-zoom-animated {
+	-webkit-transform-origin: 0 0;
+	-ms-transform-origin: 0 0;
+	transform-origin: 0 0;
+}
+.leaflet-zoom-anim .leaflet-zoom-animated {
+	will-change: transform;
+}
 .leaflet-zoom-anim .leaflet-zoom-animated {
 	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
-	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
-	     -o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1);
-	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
-	}
+	-moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
+	-o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1);
+	transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
+}
 .leaflet-zoom-anim .leaflet-tile,
-.leaflet-pan-anim .leaflet-tile,
-.leaflet-touching .leaflet-zoom-animated {
+.leaflet-pan-anim .leaflet-tile {
 	-webkit-transition: none;
-	   -moz-transition: none;
-	     -o-transition: none;
-	        transition: none;
-	}
+	-moz-transition: none;
+	-o-transition: none;
+	transition: none;
+}
 
 .leaflet-zoom-anim .leaflet-zoom-hide {
 	visibility: hidden;
-	}
+}
 
 
 /* cursors */
 
-.leaflet-clickable {
+.leaflet-interactive {
 	cursor: pointer;
-	}
-.leaflet-container {
+}
+.leaflet-grab {
 	cursor: -webkit-grab;
 	cursor:    -moz-grab;
-	}
+}
+.leaflet-crosshair,
+.leaflet-crosshair .leaflet-interactive {
+	cursor: crosshair;
+}
 .leaflet-popup-pane,
 .leaflet-control {
 	cursor: auto;
-	}
-.leaflet-dragging .leaflet-container,
-.leaflet-dragging .leaflet-clickable {
+}
+.leaflet-dragging .leaflet-grab,
+.leaflet-dragging .leaflet-grab .leaflet-interactive,
+.leaflet-dragging .leaflet-marker-draggable {
 	cursor: move;
 	cursor: -webkit-grabbing;
 	cursor:    -moz-grabbing;
-	}
+}
 
+/* marker & overlays interactivity */
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-image-layer,
+.leaflet-pane > svg path,
+.leaflet-tile-container {
+	pointer-events: none;
+}
+
+.leaflet-marker-icon.leaflet-interactive,
+.leaflet-image-layer.leaflet-interactive,
+.leaflet-pane > svg path.leaflet-interactive {
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
+	pointer-events: auto;
+}
 
 /* visual tweaks */
 
 .leaflet-container {
 	background: #ddd;
 	outline: 0;
-	}
+}
 .leaflet-container a {
 	color: #0078A8;
-	}
+}
 .leaflet-container a.leaflet-active {
 	outline: 2px solid orange;
-	}
+}
 .leaflet-zoom-box {
 	border: 2px dotted #38f;
 	background: rgba(255,255,255,0.5);
-	}
+}
 
 
 /* general typography */
 .leaflet-container {
 	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
-	}
+}
 
 
 /* general toolbar styles */
@@ -207,7 +261,7 @@
 .leaflet-bar {
 	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
 	border-radius: 4px;
-	}
+}
 .leaflet-bar a,
 .leaflet-bar a:hover {
 	background-color: #fff;
@@ -219,36 +273,36 @@
 	text-align: center;
 	text-decoration: none;
 	color: black;
-	}
+}
 .leaflet-bar a,
 .leaflet-control-layers-toggle {
 	background-position: 50% 50%;
 	background-repeat: no-repeat;
 	display: block;
-	}
+}
 .leaflet-bar a:hover {
 	background-color: #f4f4f4;
-	}
+}
 .leaflet-bar a:first-child {
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
-	}
+}
 .leaflet-bar a:last-child {
 	border-bottom-left-radius: 4px;
 	border-bottom-right-radius: 4px;
 	border-bottom: none;
-	}
+}
 .leaflet-bar a.leaflet-disabled {
 	cursor: default;
 	background-color: #f4f4f4;
 	color: #bbb;
-	}
+}
 
 .leaflet-touch .leaflet-bar a {
 	width: 30px;
 	height: 30px;
 	line-height: 30px;
-	}
+}
 
 
 /* zoom control */
@@ -257,17 +311,17 @@
 .leaflet-control-zoom-out {
 	font: bold 18px 'Lucida Console', Monaco, monospace;
 	text-indent: 1px;
-	}
+}
 .leaflet-control-zoom-out {
 	font-size: 20px;
-	}
+}
 
 .leaflet-touch .leaflet-control-zoom-in {
 	font-size: 22px;
-	}
+}
 .leaflet-touch .leaflet-control-zoom-out {
 	font-size: 24px;
-	}
+}
 
 
 /* layers control */
@@ -276,46 +330,55 @@
 	box-shadow: 0 1px 5px rgba(0,0,0,0.4);
 	background: #fff;
 	border-radius: 5px;
-	}
+}
 .leaflet-control-layers-toggle {
 	background-image: url(images/layers.png);
 	width: 36px;
 	height: 36px;
-	}
+}
 .leaflet-retina .leaflet-control-layers-toggle {
 	background-image: url(images/layers-2x.png);
 	background-size: 26px 26px;
-	}
+}
 .leaflet-touch .leaflet-control-layers-toggle {
 	width: 44px;
 	height: 44px;
-	}
+}
 .leaflet-control-layers .leaflet-control-layers-list,
 .leaflet-control-layers-expanded .leaflet-control-layers-toggle {
 	display: none;
-	}
+}
 .leaflet-control-layers-expanded .leaflet-control-layers-list {
 	display: block;
 	position: relative;
-	}
+}
 .leaflet-control-layers-expanded {
 	padding: 6px 10px 6px 6px;
 	color: #333;
 	background: #fff;
-	}
+}
+.leaflet-control-layers-scrollbar {
+	overflow-y: scroll;
+	padding-right: 5px;
+}
 .leaflet-control-layers-selector {
 	margin-top: 2px;
 	position: relative;
 	top: 1px;
-	}
+}
 .leaflet-control-layers label {
 	display: block;
-	}
+}
 .leaflet-control-layers-separator {
 	height: 0;
 	border-top: 1px solid #ddd;
 	margin: 5px -10px 5px -6px;
-	}
+}
+
+/* Default icon URLs */
+.leaflet-default-icon-path {
+	background-image: url(images/marker-icon.png);
+}
 
 
 /* attribution and scale controls */
@@ -324,28 +387,28 @@
 	background: #fff;
 	background: rgba(255, 255, 255, 0.7);
 	margin: 0;
-	}
+}
 .leaflet-control-attribution,
 .leaflet-control-scale-line {
 	padding: 0 5px;
 	color: #333;
-	}
+}
 .leaflet-control-attribution a {
 	text-decoration: none;
-	}
+}
 .leaflet-control-attribution a:hover {
 	text-decoration: underline;
-	}
+}
 .leaflet-container .leaflet-control-attribution,
 .leaflet-container .leaflet-control-scale {
 	font-size: 11px;
-	}
+}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
-	}
+}
 .leaflet-bottom .leaflet-control-scale {
 	margin-bottom: 5px;
-	}
+}
 .leaflet-control-scale-line {
 	border: 2px solid #777;
 	border-top: none;
@@ -354,31 +417,31 @@
 	font-size: 11px;
 	white-space: nowrap;
 	overflow: hidden;
-	-moz-box-sizing: content-box;
-	     box-sizing: content-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 
 	background: #fff;
 	background: rgba(255, 255, 255, 0.5);
-	}
+}
 .leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;
 	border-bottom: none;
 	margin-top: -2px;
-	}
+}
 .leaflet-control-scale-line:not(:first-child):not(:last-child) {
 	border-bottom: 2px solid #777;
-	}
+}
 
 .leaflet-touch .leaflet-control-attribution,
 .leaflet-touch .leaflet-control-layers,
 .leaflet-touch .leaflet-bar {
 	box-shadow: none;
-	}
+}
 .leaflet-touch .leaflet-control-layers,
 .leaflet-touch .leaflet-bar {
 	border: 2px solid rgba(0,0,0,0.2);
 	background-clip: padding-box;
-	}
+}
 
 
 /* popup */
@@ -386,26 +449,29 @@
 .leaflet-popup {
 	position: absolute;
 	text-align: center;
-	}
+	margin-bottom: 20px;
+}
 .leaflet-popup-content-wrapper {
 	padding: 1px;
 	text-align: left;
 	border-radius: 12px;
-	}
+}
 .leaflet-popup-content {
 	margin: 13px 19px;
 	line-height: 1.4;
-	}
+}
 .leaflet-popup-content p {
 	margin: 18px 0;
-	}
+}
 .leaflet-popup-tip-container {
-	margin: 0 auto;
 	width: 40px;
 	height: 20px;
-	position: relative;
+	position: absolute;
+	left: 50%;
+	margin-left: -20px;
 	overflow: hidden;
-	}
+	pointer-events: none;
+}
 .leaflet-popup-tip {
 	width: 17px;
 	height: 17px;
@@ -414,22 +480,23 @@
 	margin: -10px auto 0;
 
 	-webkit-transform: rotate(45deg);
-	   -moz-transform: rotate(45deg);
-	    -ms-transform: rotate(45deg);
-	     -o-transform: rotate(45deg);
-	        transform: rotate(45deg);
-	}
+	-moz-transform: rotate(45deg);
+	-ms-transform: rotate(45deg);
+	-o-transform: rotate(45deg);
+	transform: rotate(45deg);
+}
 .leaflet-popup-content-wrapper,
 .leaflet-popup-tip {
 	background: white;
-
+	color: #333;
 	box-shadow: 0 3px 14px rgba(0,0,0,0.4);
-	}
+}
 .leaflet-container a.leaflet-popup-close-button {
 	position: absolute;
 	top: 0;
 	right: 0;
 	padding: 4px 4px 0 0;
+	border: none;
 	text-align: center;
 	width: 18px;
 	height: 14px;
@@ -438,36 +505,36 @@
 	text-decoration: none;
 	font-weight: bold;
 	background: transparent;
-	}
+}
 .leaflet-container a.leaflet-popup-close-button:hover {
 	color: #999;
-	}
+}
 .leaflet-popup-scrolled {
 	overflow: auto;
 	border-bottom: 1px solid #ddd;
 	border-top: 1px solid #ddd;
-	}
+}
 
 .leaflet-oldie .leaflet-popup-content-wrapper {
 	zoom: 1;
-	}
+}
 .leaflet-oldie .leaflet-popup-tip {
 	width: 24px;
 	margin: 0 auto;
 
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
-	}
+}
 .leaflet-oldie .leaflet-popup-tip-container {
 	margin-top: -1px;
-	}
+}
 
 .leaflet-oldie .leaflet-control-zoom,
 .leaflet-oldie .leaflet-control-layers,
 .leaflet-oldie .leaflet-popup-content-wrapper,
 .leaflet-oldie .leaflet-popup-tip {
 	border: 1px solid #999;
-	}
+}
 
 
 /* div icon */
@@ -475,4 +542,83 @@
 .leaflet-div-icon {
 	background: #fff;
 	border: 1px solid #666;
-	}
+}
+
+
+/* Tooltip */
+/* Base styles for the element that has a tooltip */
+.leaflet-tooltip {
+	position: absolute;
+	padding: 6px;
+	background-color: #fff;
+	border: 1px solid #fff;
+	border-radius: 3px;
+	color: #222;
+	white-space: nowrap;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+}
+.leaflet-tooltip.leaflet-clickable {
+	cursor: pointer;
+	pointer-events: auto;
+}
+.leaflet-tooltip-top:before,
+.leaflet-tooltip-bottom:before,
+.leaflet-tooltip-left:before,
+.leaflet-tooltip-right:before {
+	position: absolute;
+	pointer-events: none;
+	border: 6px solid transparent;
+	background: transparent;
+	content: "";
+}
+
+/* Directions */
+
+.leaflet-tooltip-bottom {
+	margin-top: 6px;
+}
+.leaflet-tooltip-top {
+	margin-top: -6px;
+}
+.leaflet-tooltip-bottom:before,
+.leaflet-tooltip-top:before {
+	left: 50%;
+	margin-left: -6px;
+}
+.leaflet-tooltip-top:before {
+	bottom: 0;
+	margin-bottom: -12px;
+	border-top-color: #fff;
+}
+.leaflet-tooltip-bottom:before {
+	top: 0;
+	margin-top: -12px;
+	margin-left: -6px;
+	border-bottom-color: #fff;
+}
+.leaflet-tooltip-left {
+	margin-left: -6px;
+}
+.leaflet-tooltip-right {
+	margin-left: 6px;
+}
+.leaflet-tooltip-left:before,
+.leaflet-tooltip-right:before {
+	top: 50%;
+	margin-top: -6px;
+}
+.leaflet-tooltip-left:before {
+	right: 0;
+	margin-right: -12px;
+	border-left-color: #fff;
+}
+.leaflet-tooltip-right:before {
+	left: 0;
+	margin-left: -12px;
+	border-right-color: #fff;
+}

--- a/_assets/styles/main.scss
+++ b/_assets/styles/main.scss
@@ -45,7 +45,3 @@
 @import 'scss/components/work-case-study';
 @import 'scss/components/work-case-study-cover-image';
 @import 'scss/components/work-table';
-
-
-/* Misc CSS files. */
-@import 'leaflet.css';

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,4 +22,7 @@
     loadCSS('https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700,400italic,700italic|PT+Serif|Source+Sans+Pro');
   </script>
   <style>{% include critical.css %}</style>
+  {% if page.path contains "_posts" and page.custom_css %}
+    <link href='/assets/styles/{{ page.custom_css }}' rel='stylesheet' type='text/css'>
+  {% endif %}
 </head>

--- a/_posts/2015-05-18-mapping-geojson.md
+++ b/_posts/2015-05-18-mapping-geojson.md
@@ -4,9 +4,13 @@ title: "Mapping external GeoJSON data"
 date: 2015-05-18
 author: Tim Stallmann
 tags: cartography leaflet
+custom_css: leaflet.css
 custom_js: leaflet.js
 summary: Leaflet.js is a powerful, light-weight javascript API for mapping. In this post, I'll walk through how to use Leaflet to map GeoJSON data.
 ---
+<script type="text/javascript" src="{{ '/assets/js/main.js' | prepend: site.baseurl | prepend: site.url }}"></script>
+<script type="text/javascript" src="{{ '/assets/js/leaflet.js' | prepend: site.baseurl | prepend: site.url }}"></script>
+
 [Leaflet.js](http://www.leafletjs.com) is a powerful, light-weight javascript API for mapping. In this post, I'll walk through how to use Leaflet to map GeoJSON data. By the end, we'll have a map of earthquakes in the past 24 hours (using live USGS data) which looks like this:
 
 <img class="blog-image-large" src="/assets/img/blog/earthquakes-map.jpg" alt="Screenshot of the map of earthquakes which we'll create in this tutorial." width="500" height="202">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,8 +46,23 @@ gulp.task('build:styles:critical', function() {
         .on('error', gutil.log);
 });
 
+// Copies any other CSS files to the assets directory, to be used by pages/posts
+// that specify custom CSS files.
+gulp.task('build:styles:css', function() {
+    return gulp.src([paths.sassFiles + '/*.css'])
+      .pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
+      .pipe(cleancss())
+      .pipe(gulp.dest(paths.jekyllCssFiles))
+      .pipe(gulp.dest(paths.siteCssFiles))
+      .on('error', gutil.log);
+});
+
 // Builds all styles.
-gulp.task('build:styles', ['build:styles:main', 'build:styles:critical']);
+gulp.task('build:styles', [
+    'build:styles:main',
+    'build:styles:critical',
+    'build:styles:css'
+]);
 
 gulp.task('clean:styles', function(callback) {
     del([paths.jekyllCssFiles, paths.siteCssFiles, '_includes/critical.css']);


### PR DESCRIPTION
@kostajh I'm still not exactly sure why, but including `leaflet.css` in `main.scss` was breaking the sass gulp task in the Travis environment and for Chris locally. I've resolved the issue by removing the import of `leaflet.css` from `main.scss`, which is a good idea anyway since `leaflet.css` is only needed on one page, an old blog post. I've added a front matter element called `custom_css` to this post to pull in `leaflet.css`, and added a gulp task to copy any extraneous CSS files from `_assets` to `assets` so they will be pulled into `_site` when Jekyll builds the site.

I also noticed that the blog post's maps weren't rendering because `leaflet.js` and jQuery were being loaded too late, after the page's HTML. Since this is a one-off, I added those scripts to the blog post body to fix the issue. I think we can avoid this in the future, and if it becomes necessary to use custom CSS/JS files often, we can rethink how we're doing this. For now, this will fix the post and let us get our blog posts out!

To test:

- Check out the Travis build to confirm that the sass task is completing now, and `main.css` is being created
- Locally, make sure your site builds, and that the maps on http://localhost:3000/2015/05/18/mapping-geojson.html are rendering
- Check that `leaflet.css` is included as a source on http://localhost:3000/2015/05/18/mapping-geojson.html, but on no other blog posts