### PR TITLE
Update footnotes font size

### DIFF
--- a/_assets/styles/scss/components/_post-footnotes.scss
+++ b/_assets/styles/scss/components/_post-footnotes.scss
@@ -7,7 +7,11 @@
 .post .footnotes {
   border-top: solid 1px $dark-blue;
   color: $dark-blue;
-  font-size: .9em;
   margin-top: 3em;
   padding-top: .5em;
+
+  p,
+  li {
+    font-size: 1em;
+  }
 }


### PR DESCRIPTION
@kostajh I recently fixed a bug with blog post font sizes that was inflating the size of headings and inadvertently caused this regression. I set the font size to 1em rather than .9em because it looked better to me; .9 seems a bit too small. :shruggie: :thatface: :doge: