### PR TITLE
Issue #2828: Wrap first paragraph of posts

### DIFF
--- a/_posts/2015-06-23-a-man-a-plan-a-canal-a-savas.md
+++ b/_posts/2015-06-23-a-man-a-plan-a-canal-a-savas.md
@@ -7,13 +7,9 @@ tags: business identity
 summary: The truth behind the palindrome.
 ---
 
-Previously, on our [who we are](/team) page, I gave you a taste of the
-[meaning](/team#what-does-savas-mean) of Savas. Now let's take a deeper dive.
+Previously, on our [who we are](/team) page, I gave you a taste of the [meaning](/team#what-does-savas-mean) of Savas. Now let's take a deeper dive.
 
-For those who know me, they _think_ I'm zany. For those who know me well, they
-**know** I'm zany. For the select few who know me really well, and/or have worked
-with me, they know I have an odd obsession with
-[palindromes](http://en.wikipedia.org/wiki/Palindrome).
+For those who know me, they _think_ I'm zany. For those who know me well, they **know** I'm zany. For the select few who know me really well, and/or have worked with me, they know I have an odd obsession with [palindromes](http://en.wikipedia.org/wiki/Palindrome).
 
 This is why, when we asked [Harbor](http://www.studioharbor.com) to help us
 come up with a company identity, including designing our logo and assissting us

--- a/_posts/2015-07-09-personal-git-workflow.md
+++ b/_posts/2015-07-09-personal-git-workflow.md
@@ -7,13 +7,7 @@ tags: git productivity
 summary: A git workflow that optimizes the preservation of (your) integrity, and frequent, distributed backups
 ---
 
-One huge benefit to using a source code management system (SCMS) like the
-de-facto industry-standard [git](https://git-scm.com/) is it eases, nay,
-down-right **facilitates** collaboration. One common attribute of
-a web developer is perfectionism. At times,
-this wonderful tool and (oft) wonderful trait can be at odds with one another.
-For those of us who appreciate beautiful code, we (not me) often fear sharing
-what isn't a polished thing of beauty.
+One huge benefit to using a source code management system (SCMS) like the de-facto industry-standard [git](https://git-scm.com/) is it eases, nay, down-right **facilitates** collaboration. One common attribute of a web developer is perfectionism. At times, this wonderful tool and (oft) wonderful trait can be at odds with one another. For those of us who appreciate beautiful code, we (not me) often fear sharing what isn't a polished thing of beauty.
 
 ```php
 <?php

--- a/_posts/2015-08-04-user-revision-sanitize.md
+++ b/_posts/2015-08-04-user-revision-sanitize.md
@@ -14,13 +14,7 @@ drupal_planet_summary: |
 ---
 
 ## The general problem
-One of the most embarrassing and potentially costly things we can do as developers
-is to send emails out to real people unintentionally from a development
-environment. It happens, and often times we aren't even aware of it until the damage
-is done and a background process sends out, say, 11,000 automated emails to
-existing customers (actually happened to a former employer recently). In the
-Drupal world, there are [myriad ways](https://github.com/chrisarusso/Tilthy-Rich-Compost-Website/commit/64a558e2)
-to [attempt to address](https://github.com/chrisarusso/Tilthy-Rich-Compost-Website/blob/master/scripts/sanitize.php) this problem.
+One of the most embarrassing and potentially costly things we can do as developers is to send emails out to real people unintentionally from a development environment. It happens, and often times we aren't even aware of it until the damage is done and a background process sends out, say, 11,000 automated emails to existing customers (actually happened to a former employer recently). In the Drupal world, there are [myriad ways](https://github.com/chrisarusso/Tilthy-Rich-Compost-Website/commit/64a558e2) to [attempt to address](https://github.com/chrisarusso/Tilthy-Rich-Compost-Website/blob/master/scripts/sanitize.php) this problem.
 
 ## General solutions to the general problem
 - [maillog](https://www.drupal.org/project/maillog) - A Drupal module that

--- a/_posts/2015-08-13-drupalcamp-asheville.md
+++ b/_posts/2015-08-13-drupalcamp-asheville.md
@@ -15,13 +15,7 @@ drupal_planet_summary: |
 ---
 
 ## Drupalcamp Asheville, we're coming!
-Savas Labs will be represented at [Drupalcamp Asheville](http://www.drupalasheville.com) this year!
-[Anne](/team/anne-tomasevich/) and [Chris](/team/chris-russo/)
-are both presenting. Anne will present on Drupal 8 theming, roughly based off
-her [blog post about it](/2015/06/10/d8-theming-basics.html), a topic with
-very little reliable information out there in the wild, and Chris is presenting
-on his "personal git workflow, for everyone," which is also based off a
-[blog post he wrote recently](/2015/07/09/personal-git-workflow.html).
+Savas Labs will be represented at [Drupalcamp Asheville](http://www.drupalasheville.com) this year! [Anne](/team/anne-tomasevich/) and [Chris](/team/chris-russo/) are both presenting. Anne will present on Drupal 8 theming, roughly based off her [blog post about it](/2015/06/10/d8-theming-basics.html), a topic with very little reliable information out there in the wild, and Chris is presenting on his "personal git workflow, for everyone," which is also based off a [blog post he wrote recently](/2015/07/09/personal-git-workflow.html).
 
 We're excited to head to beautiful Asheville to teach, share and learn. We
 might even get a hike in and some craft beer while we're at it.

--- a/_posts/2015-08-24-drupalcamp-asheville-recap.md
+++ b/_posts/2015-08-24-drupalcamp-asheville-recap.md
@@ -9,11 +9,7 @@ summary: |
 ---
 
 ## Drupalcamp Asheville, we're leaving!
-Drupalcamp Asheville was an all around success for Savas Labs. It was our first
-public camp/conference that we presented at. Anne's presentation on Drupal 8
-themeing went swimmingly (and rapidly) to a sold out crowd, and most of my
-attendees (though as confirmed by one of them after, not all) did _not_
-fall asleep covering personal git workflow.
+Drupalcamp Asheville was an all around success for Savas Labs. It was our first public camp/conference that we presented at. Anne's presentation on Drupal 8 themeing went swimmingly (and rapidly) to a sold out crowd, and most of my attendees (though as confirmed by one of them after, not all) did _not_ fall asleep covering personal git workflow.
 
 Among the many solid sessions, a highlight was [Ryan Szrama](https://twitter.com/ryanszrama)'s
 Offspring music as well as his sharing of a recent foray into the modern PHP

--- a/_posts/2015-10-23-all-things-open-conference.md
+++ b/_posts/2015-10-23-all-things-open-conference.md
@@ -8,17 +8,7 @@ summary: Attending and sharing experiences from the All Things Open conference.
 
 ---
 
-Last week, I attended the
-[All Things Open conference](http://allthingsopen.org/) conference. The
-conference is hosted in Raleigh, so for those of us carless folks, it is a very
-accessible world-class conference a mere 30-minute bus ride away. I attended
-the conference last year (its 2nd year running) and enjoyed a shallow dive
-into a [wide variety](http://allthingsopen.org/schedule/) of open source
-technologies. Some of which was applicable to the work I was doing, and some of
-which was more geared towards inspiration, new ideas, and learning about
-technologies that I could utilize or at least should be aware of. This
-year I attended with a similar perspective, but also with my employer (red) hat
-([and shoes](https://twitter.com/Savas_Labs/status/656108971175116801)) on.
+Last week, I attended the [All Things Open conference](http://allthingsopen.org/) conference. The conference is hosted in Raleigh, so for those of us carless folks, it is a very accessible world-class conference a mere 30-minute bus ride away. I attended the conference last year (its 2nd year running) and enjoyed a shallow dive into a [wide variety](http://allthingsopen.org/schedule/) of open source technologies. Some of which was applicable to the work I was doing, and some of which was more geared towards inspiration, new ideas, and learning about technologies that I could utilize or at least should be aware of. This year I attended with a similar perspective, but also with my employer (red) hat ([and shoes](https://twitter.com/Savas_Labs/status/656108971175116801)) on.
 
 It was fun to network and discuss opportunities of diversity with organizations
 like [girl develop it](https://www.girldevelopit.com/) and advocate that the

--- a/_posts/2015-11-05-drupal-web-mapping.md
+++ b/_posts/2015-11-05-drupal-web-mapping.md
@@ -7,8 +7,7 @@ tags: drupal drupal-planet cartography
 summary: Slides from Tim's talk on building web maps using Drupal at the 2015 NACIS conference.
 ---
 
-Two weeks ago, I gave a presentation on [Drupalized Web Mapping](http://timstallmann.github.io/nacis-drupal-mapping-talk/#/) for the [North American Cartographic Information Society 2015](http://www.nacis.org) conference in Minneapolis, MN.
-The full set of slides for the talk are [online via Github pages](http://timstallmann.github.io/nacis-drupal-mapping-talk/#/), but here I'm going to skip the "what is Drupal" side of the talk and focus on giving more detail on three different recommended workflows for building web maps in Drupal.
+Two weeks ago, I gave a presentation on [Drupalized Web Mapping](http://timstallmann.github.io/nacis-drupal-mapping-talk/#/) for the [North American Cartographic Information Society 2015](http://www.nacis.org) conference in Minneapolis, MN. The full set of slides for the talk are [online via Github pages](http://timstallmann.github.io/nacis-drupal-mapping-talk/#/), but here I'm going to skip the "what is Drupal" side of the talk and focus on giving more detail on three different recommended workflows for building web maps in Drupal.
 
 Note: At the time of writing this few of the modules mentioned had stable D8 ports. The shift to D8 is likely to change the landscape of mapping modules significantly, so the following advice is really focused on D7 sites (although we're using the third approach on a D8 site currently).
 

--- a/_posts/2015-11-24-drupal-6-upgrade.md
+++ b/_posts/2015-11-24-drupal-6-upgrade.md
@@ -7,8 +7,7 @@ tags: drupal drupal8 drupal-planet
 summary: What to plan for as Drupal 6 EOL approaches.
 
 ---
-This is part 1 of a series investigating what to do with your Drupal 6 site as
-EOL approaches.
+This is part 1 of a series investigating what to do with your Drupal 6 site as EOL approaches.
 
 **Part 1 - overview** \|
 [Part 2 - the risks](/2015/12/10/drupal-6-part-2.html)

--- a/_posts/2015-12-10-drupal-6-part-2.md
+++ b/_posts/2015-12-10-drupal-6-part-2.md
@@ -14,8 +14,7 @@ drupal_planet_summary: |
   EOL approaches. This post takes a deep dive into the risks specifically.
 ---
 
-This is part 2 of a series investigating what to do with your Drupal 6 site as
-EOL approaches.
+This is part 2 of a series investigating what to do with your Drupal 6 site as EOL approaches.
 
 [Part 1 - overview](/2015/11/24/drupal-6-upgrade.html) \| **Part 2 - the risks**
  \| [Part 3 - the options](/2016/01/25/drupal-6-part-3.html)

--- a/_posts/2016-01-25-drupal-6-part-3.md
+++ b/_posts/2016-01-25-drupal-6-part-3.md
@@ -16,8 +16,7 @@ drupal_planet_summary:
   level of risk and tolerance for it, and other business priorities.
 ---
 
-This is part 3 of a series investigating what to do with your Drupal 6 site as
-EOL approaches.
+This is part 3 of a series investigating what to do with your Drupal 6 site as EOL approaches.
 
 [Part 1 - overview](/2015/11/24/drupal-6-upgrade.html) \|
 [Part 2 - the risks](/2015/12/10/drupal-6-part-2.html)

--- a/_posts/2016-02-24-drupal-6-part-4.md
+++ b/_posts/2016-02-24-drupal-6-part-4.md
@@ -15,8 +15,7 @@ drupal_planet_summary:
   site.
 ---
 
-This is part 4 of a series investigating what to do with your Drupal 6 site as
-EOL has now come.
+This is part 4 of a series investigating what to do with your Drupal 6 site as EOL has now come.
 
 [Part 1 - overview](/2015/11/24/drupal-6-upgrade.html) \|
 [Part 2 - the risks](/2015/12/10/drupal-6-part-2.html) \|

--- a/_posts/2016-03-02-drupalcon-2016-session-submissions.md
+++ b/_posts/2016-03-02-drupalcon-2016-session-submissions.md
@@ -11,11 +11,7 @@ summary: Savas Labs is sending 3 people to Drupalcon and has proposed 4 sessions
 
 ## 4 Savas Labs sessions proposed for Drupalcon NA 2016
 
-Lisa, [Kosta](/team/kosta-harlan/) and [I](/team/chris-russo) will be heading over to [The Big Easy](https://en.wikipedia.org/wiki/New_Orleans) in early May for this
-year's [Drupalcon North America](https://events.drupal.org/neworleans2016). The week promises to be filled with some
-high-quality brain transfer (via HTTP 2 of course), meeting in-person with those who we only know digitally on IRC or
-in the issue queue, and general Drupal gallivanting ...where we plan to see
-people like this...
+Lisa, [Kosta](/team/kosta-harlan/) and [I](/team/chris-russo) will be heading over to [The Big Easy](https://en.wikipedia.org/wiki/New_Orleans) in early May for this year's [Drupalcon North America](https://events.drupal.org/neworleans2016). The week promises to be filled with some high-quality brain transfer (via HTTP 2 of course), meeting in-person with those who we only know digitally on IRC or in the issue queue, and general Drupal gallivanting ...where we plan to see people like this...
 
 <img src="/assets/img/blog/druplicon-in-durham.jpg" alt="Druplicon in Durham">
 

--- a/_posts/2016-03-10-drupal-camp-florida-2016-recap.md
+++ b/_posts/2016-03-10-drupal-camp-florida-2016-recap.md
@@ -11,11 +11,7 @@ summary: Lisa Ridley of Savas Labs attended Drupal Camp Florida in March 2016.  
 
 ## Drupal Camp Florida 2016 Recap
 
-Last weekend, I attended [DrupalCamp Florida](https://www.fldrupal.camp/) in Orlando.  This camp has become a regular on my annual list of camps,
-and it's usually the first one on the calendar for the year.  The camp, as are most Drupal Camps, is organized entirely by volunteers, most of them members of the Orlando
-and surrounding area Drupal User Groups.  The camp is held at the Florida Technical College campus in Orlando, who graciously provides the use of their facilities at
-no cost, which (along with the generosity of the sponsors) helps to keep the cost to attendees down. This is just an extremely well run camp, and it sets the
-bar for the remainder of the year for other Drupal Camps.
+Last weekend, I attended [DrupalCamp Florida](https://www.fldrupal.camp/) in Orlando.  This camp has become a regular on my annual list of camps, and it's usually the first one on the calendar for the year.  The camp, as are most Drupal Camps, is organized entirely by volunteers, most of them members of the Orlando and surrounding area Drupal User Groups.  The camp is held at the Florida Technical College campus in Orlando, who graciously provides the use of their facilities at no cost, which (along with the generosity of the sponsors) helps to keep the cost to attendees down. This is just an extremely well run camp, and it sets the bar for the remainder of the year for other Drupal Camps.
 
 On the sessions agenda the year was, no surprise, several sessions that focused on Drupal 8, and ran the gamut:
 

--- a/_posts/2016-03-21-an-event-apart-nashville.md
+++ b/_posts/2016-03-21-an-event-apart-nashville.md
@@ -11,12 +11,7 @@ featured_image_height: "830px"
 featured_image_width: "1474px"
 ---
 
-Sitting in the Nashville airport after attending
-[An Event Apart](http://aneventapart.com/), a leading web design and development
-conference, I found myself feeling overwhelmed at the sheer volume of
-information I'd just taken in and the positively enormous possibilities lying
-ahead of the people who build the web (and the equally huge responsibility we
-have to move forward with thoughtfulness and compassion).
+Sitting in the Nashville airport after attending [An Event Apart](http://aneventapart.com/), a leading web design and development conference, I found myself feeling overwhelmed at the sheer volume of information I'd just taken in and the positively enormous possibilities lying ahead of the people who build the web (and the equally huge responsibility we have to move forward with thoughtfulness and compassion).
 
 I wasn't quite sure what to expect going in, so I'd like to summarize my biggest
 takeaways, share some of the things I found exciting, and reflect on what I

--- a/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
+++ b/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
@@ -12,16 +12,7 @@ featured_image_height: "912px"
 featured_image_width: "1474px"
 ---
 
-It's hard to believe it's been over a year and a half since our site's
-[inaugural blog post]({{ site.url }}/2015/04/01/building-our-site.html)
-(written just two months after my career change into web development!) It's been
-great fun building our site and adding content thanks to the power and simplicity
-of [Jekyll](https://jekyllrb.com/). We recently deployed a series of changes to
-optimize our CSS, JS, and images, and in doing so finally moved away from using
-built-in `jekyll` commands to build the site. Instead, we're using
-[gulp](http://gulpjs.com/), a task runner — or, as they put so nicely on their
-website, a "streaming build system". In this post I'll go over our motivations
-for this change, how we integrated gulp with Jekyll, and the awesome results!
+It's hard to believe it's been over a year and a half since our site's [inaugural blog post]({{ site.url }}/2015/04/01/building-our-site.html) (written just two months after my career change into web development!) It's been great fun building our site and adding content thanks to the power and simplicity of [Jekyll](https://jekyllrb.com/). We recently deployed a series of changes to optimize our CSS, JS, and images, and in doing so finally moved away from using built-in `jekyll` commands to build the site. Instead, we're using [gulp](http://gulpjs.com/), a task runner — or, as they put so nicely on their website, a "streaming build system". In this post I'll go over our motivations for this change, how we integrated gulp with Jekyll, and the awesome results!
 
 We based a lot of our gulp workflow on
 [this excellent post](https://robwise.github.io/blog/jekyll-and-gulp) by Rob Wise.

--- a/_posts/2017-02-27-on-web-typography-review.md
+++ b/_posts/2017-02-27-on-web-typography-review.md
@@ -13,14 +13,7 @@ summary: |
   lessons learned to our workflow.
 ---
 
-As a developer who often interacts with and creates web designs, I'm always on
-the lookout for quality resources to level up my design skills, and the [Book
-Apart series](https://abookapart.com/) has proven to be an excellent source of
-knowledge presented in a relevant, concise manner. My latest read was [*On Web
-Typography* by Jason Santa Maria](https://abookapart.com/products/on-web-typography),
-and I found the book to be a strong resource, especially for the non-designer.
-In this post, I'll review the book and detail how we at Savas Labs implemented
-the lessons we learned.
+As a developer who often interacts with and creates web designs, I'm always on the lookout for quality resources to level up my design skills, and the [Book Apart series](https://abookapart.com/) has proven to be an excellent source of knowledge presented in a relevant, concise manner. My latest read was [*On Web Typography* by Jason Santa Maria](https://abookapart.com/products/on-web-typography), and I found the book to be a strong resource, especially for the non-designer. In this post, I'll review the book and detail how we at Savas Labs implemented the lessons we learned.
 
 ## Thinking about reading
 


### PR DESCRIPTION
This fixes [issue 2828](https://pm.savaslabs.com/issues/2828), which notes that posts that use line breaks to limit line length to 80 characters will have meta descriptions that are missing spaces at those line breaks. I couldn't get the line breaks to convert to spaces in the `<meta>` tag in the HTML `<head>` via the `markdownify` Liquid filter, which converts some markdown to HTML, so instead I just edited the posts that were affected by this issue. In the future we shouldn't bother adding hard line breaks to limit line width.

Please review the changes to ensure I added spaces properly to the first paragraphs of these posts. The first paragraph (or sometimes first and second) is all that matters since the page description is truncated at 160 characters.

@ro Once you approve I will merge - thanks for doing this!