### PR TITLE
Issue #2166: Use gulp-cache to cache processed images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@
 var appendPrepend  = require('gulp-append-prepend');
 var autoprefixer   = require('autoprefixer');
 var browserSync    = require('browser-sync').create();
+var cache         = require('gulp-cache');
 var cleancss       = require('gulp-clean-css');
 var concat         = require('gulp-concat');
 var del            = require('del');
@@ -114,12 +115,12 @@ gulp.task('clean:scripts', function(callback) {
 // JPEG optimization plugin.
 gulp.task('build:images', function() {
     return gulp.src(paths.imageFilesGlob)
-        .pipe(imagemin([
+        .pipe(cache(imagemin([
             imagemin.gifsicle(),
             jpegRecompress(),
             imagemin.optipng(),
             imagemin.svgo()
-        ]))
+        ])))
         .pipe(gulp.dest(paths.jekyllImageFiles))
         .pipe(gulp.dest(paths.siteImageFiles))
         .pipe(browserSync.stream());
@@ -279,4 +280,13 @@ gulp.task('update:bundle', function() {
         .pipe(run('bundle update'))
         .pipe(notify({ message: 'Bundle Update Complete' }))
         .on('error', gutil.log);
+});
+
+/**
+ * Task: cache-clear
+ *
+ * Clears the gulp cache. Currently this just holds processed images.
+ */
+gulp.task('cache-clear', function(done) {
+    return cache.clearAll(done);
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-append-prepend": "^1.0.3",
+    "gulp-cache": "^0.4.6",
     "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",
     "gulp-imagemin": "^3.0.3",


### PR DESCRIPTION
This PR adds the `gulp-cache` plugin and uses it on the `build:images` task to create a cache of processed image that gulp compares the original `_assets/img` directory to when this process is run. Only new or updated images will be run through the `imagemin` process. This shaves a minute off the time to run `gulp build` or `gulp serve`.

To test:

- Before pulling this branch, open a finder window to the `assets/img/blog` directory (run `gulp build:images` if this doesn't exist). Take a screenshot the `assets/img/blog` directory. This will record what image sizes should be after images are run through the `imagemin` process. 
- Pull this branch and run `npm install`
- Run `gulp clean` to delete `_site` and the contents of `assets`
- Run `gulp build:images`. The `build:images` task will process all images in the `_assets/img` directory, and it will probably take longer than usual since the cache is being built. It took 3-4 minutes for me.
- Check out the `assets/img/blog` directory and compare file sizes to the screenshot you took. Make sure the image file sizes are the same. This should prove that the `images:build` task is still sending images through `imagemin` process.
- Run `gulp build:images` again. This should be much quicker, just a few seconds, since all the images are in the cache so nothing needs to be processed.
- Add an image to `_assets/img`. Run `gulp build:images`. Your new image should have been run through `imagemin` and copied to `assets`. The filesize of the file in `assets` should be smaller than the original.
- You can also try running `gulp serve` to make sure everything still works. This should take ~1 minute 10 seconds now

I still wish this were faster; it still takes Jekyll a while to generate different image sizes as part of the jekyll-picture-tag plugin. It's a step in the right direction though!