### PR TITLE
Issue #3151: CTA region

### DIFF
--- a/_assets/styles/scss/01-base/_variables.scss
+++ b/_assets/styles/scss/01-base/_variables.scss
@@ -23,7 +23,7 @@ $monospace-font: Menlo, Monaco, 'Andale Mono', 'lucida console', 'Courier New', 
 
 // Spacing and other utilities -------------------------------------------------
 $max-width: 1160px;
-$base-margin: $base-spacing * 2;
+$base-margin: $base-spacing * 3;
 $case-study-header-break: (
   columns: 12,
   gutter: 20px,

--- a/_assets/styles/scss/05-regions/_call-to-action.scss
+++ b/_assets/styles/scss/05-regions/_call-to-action.scss
@@ -34,6 +34,6 @@ category: Regions
   }
 
   .region--cta__text {
-    margin-bottom: $base-spacing;
+    margin-bottom: $base-spacing * 2;
   }
 }

--- a/_includes/regions/cta--move-work-forward.html
+++ b/_includes/regions/cta--move-work-forward.html
@@ -1,17 +1,3 @@
-/**
- * @file
- *
- * Call to action region styles.
- */
-
-/*doc
----
-title: Call to action
-name: call-to-action
-category: Regions
----
-
-```html_example
 <div class="region--cta">
   <h2 class="region--cta__heading c-orange">Move Work Forward</h2>
   <div class="region--cta__text">
@@ -21,19 +7,3 @@ category: Regions
   </div>
   <a href="/contact" class="button--arrow--orange">Get in touch</a>
 </div>
-```
-
-*/
-
-.region--cta {
-  padding: $base-margin 0;
-  text-align: center;
-
-  .region--cta__heading {
-    margin-bottom: $base-spacing;
-  }
-
-  .region--cta__text {
-    margin-bottom: $base-spacing;
-  }
-}

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ permalink: "/"
         </div>
       </div>
 
-      {% include job-posting-block.html %}
+      {% include regions/cta--move-work-forward.html %}
 
     </div>
 


### PR DESCRIPTION
**Note:** This branch was based off the button branch, so once PRs #234 and #235 are merged I will rebase this one.

This adds styles for the CTA region and a template for the "Move work forward" region on the home page. Other instances of this region (e.g. "What does Savas mean?") can be adapted from this template.

To test, check out the home page where I've added the new region, and the example in the styleguide on the Regions tab.