### PR TITLE
Refactor tiles into component templates

### DIFF
--- a/_includes/components/tile--blog.html
+++ b/_includes/components/tile--blog.html
@@ -1,0 +1,20 @@
+<div class="tile--blog tile">
+  <a href="{{ include.post.url }}" class="tile--blog__link">
+    <div class="tile--blog__content tile__content bg-light-teal">
+      {% if post.featured_image %}
+      <div class="tile--blog__image" style="background-image: url(/assets/img{{ include.post.featured_image }});">
+        {% else %}
+        <!--TODO: Default image-->
+        <!--<div class="tile--blog__image" style="background-image: url('/assets/img/blog/default.jpg');">-->
+        {% endif %}
+      </div>
+      <div class="tile--blog__post-title">
+        {{ include.post.title | markdownify }}
+      </div>
+    </div>
+    <div class="tile--blog__hover tile__hover bg-orange">
+      {{ include.post.summary | markdownify }}
+      <p class="link--cta link--cta--inverse">Read more</p>
+    </div>
+  </a>
+</div>

--- a/_includes/components/tile--case-study.html
+++ b/_includes/components/tile--case-study.html
@@ -1,0 +1,12 @@
+<div class="tile--case-study tile">
+  <a href="{{ include.item.url }}" class="tile--case-study__link">
+    <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url({{ include.item.tile_image }});">
+      <h3 class="heading--bold c-eggshell h4">{{ include.item.project_title }}</h3>
+    </div>
+    <div class="tile--case-study__hover tile__hover bg-orange">
+      {% capture tile_description %}{{ include.item.tile_description }}{% endcapture %}
+      {{ tile_description | markdownify }}
+      <p class="link--cta link--cta--inverse">Learn more</p>
+    </div>
+  </a>
+</div>

--- a/_includes/regions/blog-tiles--sharing-our-expertise.html
+++ b/_includes/regions/blog-tiles--sharing-our-expertise.html
@@ -4,26 +4,7 @@
       <h2 class="c-eggshell">Sharing Our Expertise</h2>
     </div>
     {% for post in site.posts limit:3 %}
-    <div class="tile--blog tile">
-      <a href="{{ post.url }}" class="tile--blog__link">
-        <div class="tile--blog__content tile__content bg-light-teal">
-          {% if post.featured_image %}
-          <div class="tile--blog__image" style="background-image: url(/assets/img{{ post.featured_image }});">
-            {% else %}
-            <!--TODO: Default image-->
-            <!--<div class="tile--blog__image" style="background-image: url('/assets/img/blog/default.jpg');">-->
-            {% endif %}
-          </div>
-          <div class="tile--blog__post-title">
-            {{ post.title | markdownify }}
-          </div>
-        </div>
-        <div class="tile--blog__hover tile__hover bg-orange">
-          {{ post.summary | markdownify }}
-          <p class="link--cta link--cta--inverse">Read more</p>
-        </div>
-      </a>
-    </div>
+    {% include components/tile--blog.html post=post %}
     {% endfor %}
   </div>
   <div class="region--blog-tiles__view-all-link">

--- a/_includes/regions/case-study-tiles.html
+++ b/_includes/regions/case-study-tiles.html
@@ -15,18 +15,7 @@
       {% assign items = site.case-studies | sort: 'weight' %}
       {% for item in items %}
         {% if item.featured == 1 %}
-        <div class="tile--case-study tile">
-          <a href="{{ item.url }}" class="tile--case-study__link">
-            <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url({{ item.tile_image }});">
-              <h3 class="heading--bold c-eggshell h4">{{ item.project_title }}</h3>
-            </div>
-            <div class="tile--case-study__hover tile__hover bg-orange">
-              {% capture tile_description %}{{ item.tile_description }}{% endcapture %}
-              {{ tile_description | markdownify }}
-              <p class="link--cta link--cta--inverse">Learn more</p>
-            </div>
-          </a>
-        </div>
+        {% include components/tile--case-study.html item=item %}
         {% endif %}
       {% endfor %}
     </div>


### PR DESCRIPTION
@oksana-c This PR refactors the blog and case study tiles region templates to remove the individual tile markup and abstract it into its own component template file. This way we'll be able to reuse the case study tile and blog post tile components more easily.

Thanks! 🌅 