### PR TITLE
Issue #3319: Add list of contrib modules

### DIFF
--- a/_data/drupal-modules-other.yml
+++ b/_data/drupal-modules-other.yml
@@ -7,3 +7,81 @@
 - name: Behat Drupal Extension
   number_commits: 2
   link: https://www.drupal.org/project/drupalextension
+- name: BigPipe
+  number_commits: 0
+  link: https://www.drupal.org/project/big_pipe
+- name: Commerce Discount
+  number_commits: 1
+  link: https://www.drupal.org/project/commerce_discount
+- name: Console
+  number_commits: 1
+  link: https://www.drupal.org/project/console
+- name: Date
+  number_commits: 1
+  link: https://www.drupal.org/project/date
+- name: Security Check
+  number_commits: 6
+  link: https://www.drupal.org/project/security_check
+- name: Drush
+  number_commits: 2
+  link: https://www.drupal.org/project/drush
+- name: Drush Daemon API
+  number_commits: 2
+  link: https://www.drupal.org/project/drushd
+- name: Drush REST API
+  number_commits: 3
+  link: https://www.drupal.org/project/drush_rest_api
+- name: Entityblock
+  number_commits: 1
+  link: https://www.drupal.org/project/entityblock
+- name: Feeds
+  number_commits: 0
+  link: https://www.drupal.org/project/feeds
+- name: inuit.css
+  number_commits: 8
+  link: https://www.drupal.org/project/inuit
+- name: Linkit - Enriched linking experience
+  number_commits: 1
+  link: https://www.drupal.org/project/linkit
+- name: Mandrill Incoming
+  number_commits: 1
+  link: https://www.drupal.org/project/mandrill_incoming
+- name: No Autocomplete
+  number_commits: 2
+  link: https://www.drupal.org/project/no_autocomplete
+- name: Path Breadcrumbs
+  number_commits: 1
+  link: https://www.drupal.org/project/path_breadcrumbs
+- name: Poll Cookies
+  number_commits: 4
+  link: https://www.drupal.org/sandbox/kostajh/1454452
+- name: Privatemsg
+  number_commits: 2
+  link: https://www.drupal.org/project/privatemsg
+- name: Salesforce Feeds
+  number_commits: 3
+  link: https://www.drupal.org/project/salesforce_feeds
+- name: Token Actions Extras
+  number_commits: 9
+  link: https://www.drupal.org/project/token_actions_extras
+- name: Track da files
+  number_commits: 1
+  link: https://www.drupal.org/project/track_da_files
+- name: Translatable Regions
+  number_commits: 5
+  link: https://www.drupal.org/project/translatableregions
+- name: User Revision
+  number_commits: 1
+  link: https://www.drupal.org/project/user_revision
+- name: Views GeoJSON
+  number_commits: 24
+  link: https://www.drupal.org/project/views_geojson
+- name: Views GeoJSON Drupal 8
+  number_commits: 33
+  link: https://www.drupal.org/sandbox/kostajh/2478765
+- name: Views LightSlider
+  number_commits: 3
+  link: https://www.drupal.org/sandbox/oksana-c/2696465
+- name: Vim Plugin For Drupal
+  number_commits: 2
+  link: https://www.drupal.org/project/vimrc

--- a/_data/drupal-modules-other.yml
+++ b/_data/drupal-modules-other.yml
@@ -7,9 +7,6 @@
 - name: Behat Drupal Extension
   number_commits: 2
   link: https://www.drupal.org/project/drupalextension
-- name: BigPipe
-  number_commits: 0
-  link: https://www.drupal.org/project/big_pipe
 - name: Commerce Discount
   number_commits: 1
   link: https://www.drupal.org/project/commerce_discount
@@ -24,7 +21,7 @@
   link: https://www.drupal.org/project/security_check
 - name: Drush
   number_commits: 2
-  link: https://www.drupal.org/project/drush
+  link: https://github.com/drush-ops/drush
 - name: Drush Daemon API
   number_commits: 2
   link: https://www.drupal.org/project/drushd
@@ -34,9 +31,6 @@
 - name: Entityblock
   number_commits: 1
   link: https://www.drupal.org/project/entityblock
-- name: Feeds
-  number_commits: 0
-  link: https://www.drupal.org/project/feeds
 - name: inuit.css
   number_commits: 8
   link: https://www.drupal.org/project/inuit

--- a/_pages/open-source.html
+++ b/_pages/open-source.html
@@ -14,7 +14,8 @@ excerpt: Open source contributions by Savas Labs
   {% include regions/text-block-list.html items=site.data.drupal-modules-featured %}
   <div class="delimited-list">
     <p>And many others:</p>
-    {% for module in site.data.drupal-modules-other %}
+    {% assign modules = site.data.drupal-modules-other | sort: 'number_commits' | reverse %}
+    {% for module in modules %}
     <a href="{{ module.link }}" class="delimited-list__item">{{ module.name }} ({{ module.number_commits }})</a>
     {% endfor %}
   </div>


### PR DESCRIPTION
Redmine issue [3319](https://pm.savaslabs.com/issues/3319)

Hi @AnneTee -

This PR adds this [list](https://pm.savaslabs.com/issues/8#note-5) of SL contributions to `/results/open-source/`. I got it up locally and it's working, but need to double check the following with you (in order of importance):

**1. Modules with no commits, just "issues"**
For example, the list says "1 issue", and I'm guessing this is where we've filed an issue for this project but didn't make a commit. **Should I remove these from the list?** Currently I've put them down as `number_commits: 0`, but it renders like this `BigPipe (0)` (See Pic1). 
- BigPipe
- Feeds

**2. Modules with external "main project" links**
In both cases I put the DO links in keeping with format, but they are out-of-date compared to the "real project" page. So just wanted to see what you preferred here.
- Console
  - https://drupalconsole.com/
  - https://www.drupal.org/project/console
- Drush
  - https://github.com/drush-ops/drush
  - https://www.drupal.org/project/drush

**3. Modules I looked up commit numbers for**
These modules didn't have commit numbers in the list, so I looked them up and put in the below:
- Commerce Discount - 1 commit by Dan
- Mandrill Incoming - 1 commit by Kosta
- No Autocomplete - 2 commit by Dan
- Token Action Extras - 9 commit by Dan
- Views geojson drupal 8 - 33 collective commits

**4. Removed modules**
I took these out of the list b/c they are already prominently featured higher up on the page:
- Drush rebuild
- Tournament
- Salesforce Suite
- SubDrush
- Drush Code Deploy
- Drupal uP

Let me know what needs to be changed!

**Pic1**
![sl-1](https://cloud.githubusercontent.com/assets/19154706/25149542/b0d61b9a-2433-11e7-8e0f-b8479ac3fced.png)
