### PR TITLE
Issue #3203: Finish open source page

### DIFF
--- a/_assets/styles/main.scss
+++ b/_assets/styles/main.scss
@@ -75,6 +75,7 @@
 
 // Region rules.
 @import 'scss/05-regions/banner';
+@import 'scss/05-regions/banner--drupal-meetup';
 @import 'scss/05-regions/banner--heading';
 @import 'scss/05-regions/banner--open-source';
 @import 'scss/05-regions/banner--service';

--- a/_assets/styles/scss/04-components/_delimited-list.scss
+++ b/_assets/styles/scss/04-components/_delimited-list.scss
@@ -12,7 +12,15 @@ category: Components
 ---
 
 ```html_example
-
+<div class="delimited-list">
+  <a href="https://www.drupal.org/sandbox/kostajh/2478765" class="delimited-list__item">Views GeoJSON Drupal 8 (33)</a>
+  <a href="https://www.drupal.org/project/views_geojson" class="delimited-list__item">Views GeoJSON (24)</a>
+  <a href="https://www.drupal.org/project/token_actions_extras" class="delimited-list__item">Token Actions Extras (9)</a>
+  <a href="https://www.drupal.org/project/inuit" class="delimited-list__item">inuit.css (8)</a>
+  <a href="https://www.drupal.org/project/security_check" class="delimited-list__item">Security Check (6)</a>
+  <a href="https://www.drupal.org/project/translatableregions" class="delimited-list__item">Translatable Regions (5)</a>
+  <a href="https://www.drupal.org/sandbox/kostajh/1454452" class="delimited-list__item">Poll Cookies (4)</a>
+</div>
 ```
 
 */

--- a/_assets/styles/scss/04-components/_header-navigation--menu-link.scss
+++ b/_assets/styles/scss/04-components/_header-navigation--menu-link.scss
@@ -47,7 +47,7 @@ A normal menu link plus the bold, magenta Contact link.
 
   // Styles for final menu item.
   // When not active or in hover/focus state, color should be magenta.
-  &:last-child:not(.active-nav-item):not(:hover):not(:focus) {
+  &:last-child:not(.header-navigation__active-nav-item):not(:hover):not(:focus) {
     a {
       color: $magenta;
     }

--- a/_assets/styles/scss/04-components/_text-block-list-item.scss
+++ b/_assets/styles/scss/04-components/_text-block-list-item.scss
@@ -12,7 +12,49 @@ category: Components
 ---
 
 ```html_example
-
+<div class="text-block-list-item">
+  <a href="https://www.drupal.org/project/rebuild" class="text-block-list-item__link">
+    <div class="text-block-list-item__content">
+      <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Drush Rebuild</h3>
+      <p class="text-block-list-item__text">Drush Rebuild is a utility for rebuilding your local development environments.</p>
+      <p class="link--arrow">Learn More</p>
+    </div>
+  </a>
+</div>
 ```
 
 */
+
+.text-block-list-item {
+  padding: $base-spacing;
+  text-align: center;
+
+  .text-block-list-item__link {
+    display: block;
+
+    &:hover,
+    &:focus {
+      h3,
+      p {
+        color: $orange;
+      }
+    }
+  }
+
+  .text-block-list-item__heading,
+  .text-block-list-item__text {
+    @include ease;
+
+    color: $dark-teal;
+    margin-bottom: 0;
+  }
+
+  .text-block-list-item__text {
+    margin: $base-spacing 0;
+  }
+
+  .link--arrow {
+    color: $orange;
+    text-transform: none;
+  }
+}

--- a/_assets/styles/scss/04-components/_text-block-list-item.scss
+++ b/_assets/styles/scss/04-components/_text-block-list-item.scss
@@ -26,7 +26,7 @@ category: Components
 */
 
 .text-block-list-item {
-  padding: $base-spacing;
+  padding: $base-spacing * 2 $base-spacing;
   text-align: center;
 
   .text-block-list-item__link {
@@ -46,15 +46,29 @@ category: Components
     @include ease;
 
     color: $dark-teal;
-    margin-bottom: 0;
+  }
+
+  .text-block-list-item__heading {
+    margin-bottom: $base-spacing;
   }
 
   .text-block-list-item__text {
-    margin: $base-spacing 0;
+    margin-bottom: 0;
   }
 
   .link--arrow {
     color: $orange;
+    margin-top: $base-spacing;
     text-transform: none;
   }
+
+  img {
+    display: block;
+    margin: 0 auto $base-spacing;
+    max-height: 100px;
+  }
+}
+
+.region--presentations .text-block-list-item {
+  text-align: left;
 }

--- a/_assets/styles/scss/05-regions/_banner--drupal-meetup.scss
+++ b/_assets/styles/scss/05-regions/_banner--drupal-meetup.scss
@@ -1,0 +1,53 @@
+/**
+ * @file
+ *
+ * Styles for Open Source Contributions banner region.
+ */
+
+.region--banner--drupal-meetup {
+  .region--full-width__wrapper {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    @include grid-media($medium-screen-up) {
+      flex-wrap: nowrap;
+      justify-content: space-around;
+    }
+  }
+
+  .region--banner--drupal-meetup__image {
+    img {
+      display: block;
+
+      @include grid-media($medium-screen-up) {
+        max-width: 400px;
+      }
+    }
+  }
+
+  .region--banner--drupal-meetup__text {
+    padding: $base-spacing * 3 $base-spacing;
+
+    @include grid-media($medium-screen-up) {
+      padding: $base-spacing;
+    }
+
+    h2 {
+      line-height: 1.75em;
+      margin-bottom: 0;
+      text-align: center;
+
+      @include grid-media($large-screen-up) {
+        line-height: 1.5em;
+      }
+
+      a {
+        @include grid-media($medium-screen-up) {
+          border-bottom: solid 1px transparentize($eggshell, .5);
+        }
+      }
+    }
+  }
+}

--- a/_assets/styles/scss/05-regions/_call-to-action.scss
+++ b/_assets/styles/scss/05-regions/_call-to-action.scss
@@ -38,7 +38,8 @@ category: Regions
   }
 
   .region--cta__heading {
-    margin-bottom: $base-spacing * 1.5;
+    margin: 0 auto $base-spacing * 1.5;
+    max-width: 500px;
   }
 
   .region--cta__text {

--- a/_assets/styles/scss/05-regions/_case-study-tiles.scss
+++ b/_assets/styles/scss/05-regions/_case-study-tiles.scss
@@ -39,7 +39,7 @@ category: Regions
       </div>
       <div class="tile--case-study tile">
         <a href="/results/case-studies/hptn/" class="tile--case-study__link">
-          <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url(/assets/img/work/hptn-case/hptn-tile.jpg);">
+          <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url(/assets/img/work/hptn/hptn-tile.jpg);">
             <h3 class="heading--bold c-eggshell h4">HIV Prevention Trials Network (HPTN) Site Redesign</h3>
           </div>
           <div class="tile--case-study__hover tile__hover bg-orange">
@@ -50,7 +50,7 @@ category: Regions
       </div>
       <div class="tile--case-study tile">
         <a href="/results/case-studies/pmp-civil-rights-map/" class="tile--case-study__link">
-          <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url(/assets/img/work/pmp-civil-rights-map/pmp-tile.jpg);">
+          <div class="tile--case-study__content tile__content bg-dark-teal" style="background-image: url(/assets/img/work/pmp-civil-rights-map/pmp-civil-rights-map-tile.jpg);">
             <h3 class="heading--bold c-eggshell h4">Durham Civil and Human Rights History Map</h3>
           </div>
           <div class="tile--case-study__hover tile__hover bg-orange">

--- a/_assets/styles/scss/05-regions/_previous-next-links.scss
+++ b/_assets/styles/scss/05-regions/_previous-next-links.scss
@@ -12,8 +12,8 @@ category: Regions
 ---
 
 ```html_example
-<div class="region--prev-next-links pagination">
-  <div class=outer-container">
+<div class="region--prev-next-links region--prev-next-links--post pagination">
+  <div class="outer-container">
     <a href="/2017/02/27/on-web-typography-review.html" class="pagination__previous"><i class="fa fa-angle-left "></i> Prev</a>
     <a href="/blog" class="pagination__view-all">View All Blog Posts</a>
     <a href="/2017/03/20/lightning-q1-2017.html" class="pagination__next"> Next <i class="fa fa-angle-right"></i></a>

--- a/_assets/styles/scss/05-regions/_service-tiles.scss
+++ b/_assets/styles/scss/05-regions/_service-tiles.scss
@@ -67,19 +67,18 @@ category: Regions
 */
 
 .region--service-tiles {
-  align-items: flex-start;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   margin-top: .25em;
 
   > div {
-    flex-basis: 100%;
+    width: 100%;
     padding-bottom: $base-spacing / 4;
     padding-top: $base-spacing / 4;
 
     @include grid-media($medium-screen-up) {
-      flex-basis: 50%;
+      width: 50%;
 
       &:first-child,
       &:nth-child(3) {

--- a/_assets/styles/scss/05-regions/_service-tiles.scss
+++ b/_assets/styles/scss/05-regions/_service-tiles.scss
@@ -73,9 +73,9 @@ category: Regions
   margin-top: .25em;
 
   > div {
-    width: 100%;
     padding-bottom: $base-spacing / 4;
     padding-top: $base-spacing / 4;
+    width: 100%;
 
     @include grid-media($medium-screen-up) {
       width: 50%;

--- a/_assets/styles/scss/05-regions/_text-block-list.scss
+++ b/_assets/styles/scss/05-regions/_text-block-list.scss
@@ -80,6 +80,7 @@ category: Regions
   .text-block-list-item {
     border-bottom: solid 1px $light-grey;
     border-right: solid 1px $light-grey;
+    position: relative;
     width: 50%;
 
     @include grid-media($large-screen-up) {
@@ -97,6 +98,18 @@ category: Regions
     &:nth-last-child(2),
     &:last-child {
       border-bottom: 0;
+    }
+
+    &::after {
+      background: $white;
+      bottom: -15px;
+      content: '';
+      display: block;
+      height: 30px;
+      position: absolute;
+      right: -15px;
+      width: 30px;
+      z-index: 2;
     }
   }
 }

--- a/_assets/styles/scss/05-regions/_text-block-list.scss
+++ b/_assets/styles/scss/05-regions/_text-block-list.scss
@@ -12,7 +12,124 @@ category: Regions
 ---
 
 ```html_example
-
+<div class="region--text-block-list">
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/project/rebuild" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Drush Rebuild</h3>
+        <p class="text-block-list-item__text">Drush Rebuild is a utility for rebuilding your local development environments.</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/project/tournament" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Tournament</h3>
+        <p class="text-block-list-item__text">This module provides a full tournament management system for Drupal.</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/project/salesforce" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Salesforce Suite</h3>
+        <p class="text-block-list-item__text">This suite of modules supports integration with Salesforce by synchronizing Drupal entities with Salesforce objects.</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/sandbox/kostajh/1978148" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">SubDrush</h3>
+        <p class="text-block-list-item__text">Drush integration for Sublime Text 3.</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/sandbox/kostajh/1965494" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Drush Code Deploy</h3>
+        <p class="text-block-list-item__text">Drush Code Deploy provides a set of commands for deploying code changes via Git to a remote environment.</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+  <div class="text-block-list-item">
+    <a href="https://www.drupal.org/project/drupal_up" class="text-block-list-item__link">
+      <div class="text-block-list-item__content">
+        <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">Drupal Up</h3>
+        <p class="text-block-list-item__text">Drupal-up is a Drush extension that facilitates building virtual machines for local development of Drupal sites</p>
+        <p class="link--arrow">Learn More</p>
+      </div>
+    </a>
+  </div>
+</div>
 ```
 
 */
+
+.region--text-block-list {
+  display: flex;
+  flex-wrap: wrap;
+  margin: $base-margin 0;
+
+  .text-block-list-item {
+    border-bottom: solid 1px $light-grey;
+    border-right: solid 1px $light-grey;
+    width: 50%;
+
+    @include grid-media($large-screen-up) {
+      width: 33%;
+    }
+
+    @include grid-media($extra-large-screen-up) {
+      width: 25%;
+    }
+
+    // This seems insane, but this sets the borders up correctly at various
+    // screen sizes.
+    &:nth-child(2n) {
+      border-right: 0;
+
+      @include grid-media($large-screen-up) {
+        border-right: solid 1px $light-grey;
+      }
+    }
+
+    &:nth-child(3n) {
+      @include grid-media($large-screen-up) {
+        border-right: 0;
+      }
+
+      @include grid-media($extra-large-screen-up) {
+        border-right: solid 1px $light-grey;
+      }
+    }
+
+    &:nth-child(4n) {
+      @include grid-media($extra-large-screen-up) {
+        border-right: 0;
+      }
+    }
+
+    &:nth-last-child(2),
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    &:nth-last-child(3) {
+      @include grid-media($large-screen-up) {
+        border-bottom: 0;
+      }
+
+      @include grid-media($extra-large-screen-up) {
+        border-bottom: solid 1px $light-grey;
+      }
+
+    }
+  }
+}

--- a/_assets/styles/scss/05-regions/_text-block-list.scss
+++ b/_assets/styles/scss/05-regions/_text-block-list.scss
@@ -83,21 +83,32 @@ category: Regions
     width: 50%;
 
     @include grid-media($large-screen-up) {
-      width: 33%;
-    }
-
-    @include grid-media($extra-large-screen-up) {
       width: 25%;
     }
 
-    // This seems insane, but this sets the borders up correctly at various
-    // screen sizes.
     &:nth-child(2n) {
       border-right: 0;
 
       @include grid-media($large-screen-up) {
         border-right: solid 1px $light-grey;
       }
+    }
+
+    &:nth-last-child(2),
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+}
+
+.region--drupal-contributions .region--text-block-list {
+  .text-block-list-item {
+    @include grid-media($large-screen-up) {
+      width: 33%;
+    }
+
+    @include grid-media($extra-large-screen-up) {
+      width: 25%;
     }
 
     &:nth-child(3n) {
@@ -116,11 +127,6 @@ category: Regions
       }
     }
 
-    &:nth-last-child(2),
-    &:last-child {
-      border-bottom: 0;
-    }
-
     &:nth-last-child(3) {
       @include grid-media($large-screen-up) {
         border-bottom: 0;
@@ -130,6 +136,20 @@ category: Regions
         border-bottom: solid 1px $light-grey;
       }
 
+    }
+  }
+}
+
+.region--presentations .region--text-block-list {
+  .text-block-list-item {
+    @include grid-media($large-screen-up) {
+      border-bottom: 0;
+    }
+
+    &:last-child {
+      @include grid-media($large-screen-up) {
+        border-right: 0;
+      }
     }
   }
 }

--- a/_data/drupal-modules-featured.yml
+++ b/_data/drupal-modules-featured.yml
@@ -1,5 +1,7 @@
 # Drupal modules we maintain or contribute to, to be output as text block list
 # items on the Open Source page.
+# NOTE: If you add another item, the SCSS will need to be updated to generate
+# the proper borders!
 
 - name: Drush Rebuild
   description: |

--- a/_data/drupal-modules-featured.yml
+++ b/_data/drupal-modules-featured.yml
@@ -17,7 +17,7 @@
   link: https://www.drupal.org/project/salesforce
 - name: SubDrush
   description: |
-    Drush integration for Sublime Text 3.
+    This project offers a Drush integration for the Sublime Text 3 text editor.
   link: https://www.drupal.org/sandbox/kostajh/1978148
 - name: Drush Code Deploy
   description: |

--- a/_data/presentations.yml
+++ b/_data/presentations.yml
@@ -1,4 +1,7 @@
 # Presentations by Savas Labs team members.
+# NOTE: If you add another item, the SCSS will need to be updated to generate
+# the proper borders!
+# Add new items to the top of the list.
 
 - title: "Total value of ownership: Drupal 8 and beyond"
   event: DrupalCon New Orleans 2016

--- a/_includes/components/text-block-list-item--presentation.html
+++ b/_includes/components/text-block-list-item--presentation.html
@@ -1,9 +1,9 @@
 <div class="text-block-list-item">
   <a href="{{ include.item.link }}" class="text-block-list-item__link">
     <img src="/assets/img/icons-and-logos/{{ include.item.icon }}" alt="{{ include.item.event }}">
-    <h3 class="heading--bold heading--sans-serif h4">{{ include.item.title }}</h3>
-    <p>{{ include.item.event }}</p>
-    <p>{{ include.item.team-member }}</p>
+    <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">{{ include.item.title }}</h3>
+    <p class="text-block-list-item__text"><strong>{{ include.item.event }}</strong></p>
+    <p  class="text-block-list-item__text">{{ include.item.team-member }}</p>
     <p class="link--arrow">Learn More</p>
   </a>
 </div>

--- a/_includes/components/text-block-list-item.html
+++ b/_includes/components/text-block-list-item.html
@@ -1,7 +1,9 @@
 <div class="text-block-list-item">
   <a href="{{ include.item.link }}" class="text-block-list-item__link">
-    <h3 class="heading--bold heading--sans-serif h4">{{ include.item.name }}</h3>
-    <p>{{ include.item.description }}</p>
-    <p class="link--arrow">Learn More</p>
+    <div class="text-block-list-item__content">
+      <h3 class="text-block-list-item__heading heading--bold heading--sans-serif h4">{{ include.item.name }}</h3>
+      <p class="text-block-list-item__text">{{ include.item.description }}</p>
+      <p class="link--arrow">Learn More</p>
+    </div>
   </a>
 </div>

--- a/_includes/regions/banner--drupal-meetup.html
+++ b/_includes/regions/banner--drupal-meetup.html
@@ -1,9 +1,9 @@
-<div class="region--banner region--banner--open-source region--full-width {{ include.class }}">
+<div class="region--banner region--banner--drupal-meetup region--full-width {{ include.class }}">
   <div class="region--full-width__wrapper">
-    <div class="region--banner--open-source__image">
+    <div class="region--banner--drupal-meetup__image">
       <img src="/assets/img/tridug-meetup.jpg" alt="A Drupal meetup member presenting at an event">
     </div>
-    <div class="region--banner--open-source__text">
+    <div class="region--banner--drupal-meetup__text">
       <h2 class="heading--bold c-eggshell">ORGANIZER:
         <a href="https://www.meetup.com/triDUG/" class="heading--sans-serif link--light link--light--no-hover">
           TriDUG Drupal MeetUp

--- a/_pages/open-source.html
+++ b/_pages/open-source.html
@@ -8,7 +8,7 @@ excerpt: Open source contributions by Savas Labs
 
 {% include regions/hero--open-source.html %}
 
-<div class="region--drupal-contributions region--text-block-list region">
+<div class="region--drupal-contributions region">
   <h2 class="heading--underline--orange">Giving Back to the Drupal Community</h2>
   <p>Savas Labs maintains and contributes to a number of Drupal modules.</p>
   {% include regions/text-block-list.html items=site.data.drupal-modules-featured %}

--- a/_pages/open-source.html
+++ b/_pages/open-source.html
@@ -23,7 +23,7 @@ excerpt: Open source contributions by Savas Labs
 
 {% include regions/banner--drupal-meetup.html class="bg-orange" %}
 
-<div class="region--presentations region--text-block-list region">
+<div class="region--presentations region">
   <h2 class="heading--underline--orange">Presentations</h2>
   {% include regions/text-block-list--presentations.html items=site.data.presentations %}
 </div>


### PR DESCRIPTION
@oksana-c This wraps up the open source page, styling the text block lists and the Drupal Meetup banner. I also added some items to the style guide and corrected some errors I found in it. I'd like to eventually add image styles, but we're pretty much done with the style guide now! (Done is a relative term, I'd still like to style it to resemble the new site design.)

Two comments about this...

- You'll notice that the borders don't look exactly like the mockup - it's possible, but pretty tricky, and would take a lot of custom code to get right. I held off on finishing this because...
- The way I've got this set up isn't very maintainable anyway. To ensure the borders show in right places I had to target specific elements and the styles will need to be updated if we add to the Drupal modules or presentations lists. Please let me know if you have any suggestions, otherwise we can come back to this at another time to see if there's a smarter way to set this up

Thanks!

P.S. I also fixed the issue with the Contact menu item!