### PR TITLE
Tag pages and contact page

### DIFF
--- a/_assets/styles/critical.scss
+++ b/_assets/styles/critical.scss
@@ -68,5 +68,6 @@
 @import 'scss/05-regions/service-tiles';
 
 // Layout and page-level rules.
+@import 'scss/06-pages/contact';
 @import 'scss/06-pages/post';
 @import 'scss/06-pages/service';

--- a/_assets/styles/main.scss
+++ b/_assets/styles/main.scss
@@ -112,3 +112,4 @@
 @import 'scss/06-pages/post';
 @import 'scss/06-pages/service';
 @import 'scss/06-pages/services';
+@import 'scss/06-pages/tag';

--- a/_assets/styles/main.scss
+++ b/_assets/styles/main.scss
@@ -107,6 +107,7 @@
 @import 'scss/06-pages/case-studies';
 @import 'scss/06-pages/case-study';
 @import 'scss/06-pages/company';
+@import 'scss/06-pages/contact';
 @import 'scss/06-pages/home';
 @import 'scss/06-pages/results';
 @import 'scss/06-pages/post';

--- a/_assets/styles/scss/01-base/_mixins.scss
+++ b/_assets/styles/scss/01-base/_mixins.scss
@@ -79,6 +79,17 @@
   }
 }
 
+@mixin link-arrow() {
+  text-transform: uppercase;
+
+  &::after {
+    content: '\f105';
+    font-family: FontAwesome;
+    font-size: 1.25em;
+    margin-left: .75em;
+  }
+}
+
 @mixin button($background-color: $white, $color: $teal) {
   background-color: transparent;
   border: solid 2px $color;

--- a/_assets/styles/scss/03-typography/_links--arrow.scss
+++ b/_assets/styles/scss/03-typography/_links--arrow.scss
@@ -23,12 +23,5 @@ parent: links
 */
 
 .link--arrow {
-  text-transform: uppercase;
-
-  &::after {
-    content: '\f105';
-    font-family: FontAwesome;
-    font-size: 1.25em;
-    margin-left: .75em;
-  }
+  @include link-arrow;
 }

--- a/_assets/styles/scss/04-components/_tiles--blog--detailed.scss
+++ b/_assets/styles/scss/04-components/_tiles--blog--detailed.scss
@@ -39,6 +39,9 @@ parent: tiles
 */
 
 .tile--blog--detailed {
+  flex-basis: auto;
+  flex-grow: 0;
+
   .tile--blog__image {
     position: relative;
 

--- a/_assets/styles/scss/04-components/_tiles--blog.scss
+++ b/_assets/styles/scss/04-components/_tiles--blog.scss
@@ -43,10 +43,9 @@ parent: tiles
 .tile--blog {
   flex-basis: 300px;
   flex-grow: 1;
-  flex-shrink: 0;
 
   @include grid-media($large-screen-up) {
-    flex-basis: 25%;
+    width: 25%;
   }
 }
 

--- a/_assets/styles/scss/05-regions/_banner--heading.scss
+++ b/_assets/styles/scss/05-regions/_banner--heading.scss
@@ -5,6 +5,7 @@
  */
 
 .region--banner--heading {
+  background: url('/assets/img/bg/diamond-texture.svg') $teal repeat;
   margin: 0 0 $base-spacing * .75;
 
   .region--banner--heading__text {
@@ -19,15 +20,18 @@
 
     h1,
     h1::after {
-      @include grid-media($medium-screen-up) {
-        margin-bottom: 0;
-      }
+      margin-bottom: 0;
     }
 
     p {
       font-style: italic;
       margin-bottom: 0;
+      margin-top: $base-spacing;
       text-transform: uppercase;
+
+      @include grid-media($medium-screen-up) {
+        margin-top: 0;
+      }
     }
   }
 }

--- a/_assets/styles/scss/05-regions/_blog-tiles--all.scss
+++ b/_assets/styles/scss/05-regions/_blog-tiles--all.scss
@@ -8,18 +8,18 @@
   .region--blog-tiles--all__tiles {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: flex-start;
 
     > div {
-      flex-basis: 100%;
+      width: 100%;
       padding: $base-spacing;
 
       @include grid-media($medium-screen-up) {
-        flex-basis: 50%;
+        width: 50%;
       }
 
       @include grid-media($large-screen-up) {
-        flex-basis: 33%;
+        width: 33.333%;
       }
     }
   }

--- a/_assets/styles/scss/05-regions/_blog-tiles--all.scss
+++ b/_assets/styles/scss/05-regions/_blog-tiles--all.scss
@@ -11,8 +11,8 @@
     justify-content: flex-start;
 
     > div {
-      width: 100%;
       padding: $base-spacing;
+      width: 100%;
 
       @include grid-media($medium-screen-up) {
         width: 50%;

--- a/_assets/styles/scss/05-regions/_blog-tiles--latest.scss
+++ b/_assets/styles/scss/05-regions/_blog-tiles--latest.scss
@@ -8,7 +8,7 @@
   .region--blog-tiles--latest__wrapper {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: flex-start;
 
     @include grid-media($large-screen-up) {
       flex-direction: column;

--- a/_assets/styles/scss/05-regions/_case-study-blocks--small.scss
+++ b/_assets/styles/scss/05-regions/_case-study-blocks--small.scss
@@ -66,16 +66,18 @@ For smaller case study blocks.
 .region--case-study-blocks.region--case-study-blocks--small {
   .region--case-study-blocks__case-studies {
     @include grid-media($medium-screen-up) {
-      justify-content: space-between;
+      justify-content: flex-start;
     }
 
     > div {
+      padding: $base-spacing;
+
       @include grid-media($medium-screen-up) {
-        width: 49%;
+        width: 50%;
       }
 
       @include grid-media($large-screen-up) {
-        width: 32%;
+        width: 33.333%;
       }
     }
   }

--- a/_assets/styles/scss/05-regions/_post-aside.scss
+++ b/_assets/styles/scss/05-regions/_post-aside.scss
@@ -47,13 +47,14 @@
       margin-bottom: $base-spacing;
 
       @include grid-media($medium-screen-up) {
-        flex-basis: 48.5%;
         flex-grow: 0;
         margin-bottom: 0;
+        width: 48.5%;
       }
 
       @include grid-media($large-screen-up) {
         margin-bottom: $base-spacing;
+        width: 100%;
       }
     }
   }

--- a/_assets/styles/scss/06-pages/_blog.scss
+++ b/_assets/styles/scss/06-pages/_blog.scss
@@ -5,10 +5,6 @@
  */
 
 .page--blog {
-  .region--banner--heading {
-    background: url('/assets/img/bg/diamond-texture.svg') $teal repeat;
-  }
-
   .region--blog-tiles--latest,
   .region--footer {
     margin-top: 0;

--- a/_assets/styles/scss/06-pages/_contact.scss
+++ b/_assets/styles/scss/06-pages/_contact.scss
@@ -1,0 +1,65 @@
+/**
+ * @file
+ *
+ * Styles for the Contact page.
+ */
+
+.page--contact__content {
+  @include grid-media($medium-screen-up) {
+    max-width: 80%;
+  }
+
+  @include grid-media($large-screen-up) {
+    max-width: $max-width - 40;
+  }
+
+  .page--contact__content-wrapper {
+    @include grid-media($large-screen-up) {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+}
+
+
+.page--contact__copy {
+  @include grid-media($large-screen-up) {
+    margin-right: $base-spacing * 1.5;
+    max-width: 350px;
+  }
+
+  .table--minimal--contact {
+    margin-top: $base-spacing * 1.5;
+  }
+
+  .table--minimal__first-column {
+    width: 33.333%;
+  }
+
+  .table--minimal--contact__label {
+    font-weight: bold;
+  }
+}
+
+.page--contact__image {
+  text-align: center;
+
+  @include grid-media($large-screen-up) {
+    max-width: 600px;
+    text-align: right;
+  }
+
+  img {
+    display: block;
+    margin-bottom: $base-margin;
+  }
+
+  a {
+    color: $orange;
+
+    &:hover,
+    &:focus {
+      color: $magenta;
+    }
+  }
+}

--- a/_assets/styles/scss/06-pages/_contact.scss
+++ b/_assets/styles/scss/06-pages/_contact.scss
@@ -45,7 +45,7 @@
   text-align: center;
 
   @include grid-media($large-screen-up) {
-    max-width: 600px;
+    flex-basis: 50%;
     text-align: right;
   }
 

--- a/_assets/styles/scss/06-pages/_tag.scss
+++ b/_assets/styles/scss/06-pages/_tag.scss
@@ -1,0 +1,23 @@
+/**
+ * @file
+ *
+ * Styles for tag pages.
+ */
+
+.page--tag {
+  .view-more-link a {
+    @include link-arrow;
+
+    @include grid-media($medium-screen-up) {
+      @include button-arrow($white, $orange);
+    }
+  }
+
+  .tag__related-posts {
+    padding-bottom: 0;
+  }
+
+  .region--blog-tiles--all__tiles {
+    margin-bottom: $base-spacing * 1.5;
+  }
+}

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,6 +1,0 @@
-<div class="contact-block">
-  <div class="contact-block__items">
-    <h3>Interested in working with us?</h3>
-    <a href="/contact">Get in touch!</a>
-  </div>
-</div>

--- a/_includes/regions/blog-tiles--related--post.html
+++ b/_includes/regions/blog-tiles--related--post.html
@@ -1,15 +1,13 @@
-<div class="region--post-aside__section__items region--post-aside__section--posts__items">
-  {% assign tile_count = 0 %}
-  {% assign post_urls = '' %}
-  {% for post in site.posts %}
-  {% for tag in include.tags %}
-  {% if post.tags contains tag and tile_count < include.limit %}
-  {% unless post_urls contains post.url %}
-  {% include components/tile--blog--detailed.html post=post %}
-  {% assign post_urls = post_urls | append: post.url %}
-  {% assign tile_count = tile_count | plus:1 %}
-  {% endunless %}
-  {% endif %}
-  {% endfor %}
-  {% endfor %}
-</div>
+{% assign tile_count = 0 %}
+{% assign post_urls = '' %}
+{% for post in site.posts %}
+{% for tag in include.tags %}
+{% if post.tags contains tag and tile_count < include.limit %}
+{% unless post_urls contains post.url %}
+{% include components/tile--blog--detailed.html post=post %}
+{% assign post_urls = post_urls | append: post.url %}
+{% assign tile_count = tile_count | plus:1 %}
+{% endunless %}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/_includes/regions/case-study-blocks--related--post.html
+++ b/_includes/regions/case-study-blocks--related--post.html
@@ -1,17 +1,15 @@
-{% comment %} Prints small case study blocks for related case studies, limit 2. {% endcomment %}
-<div class="region--post-aside__section__items region--post-aside__section--posts__items">
-  {% assign items = site.case-studies | sort: 'weight' %}
-  {% assign block_count = 0 %}
-  {% assign case_study_titles = '' %}
-  {% for item in items %}
-  {% for tag in include.tags %}
-  {% if item.tags contains tag and block_count < include.limit %}
-  {% unless case_study_titles contains item.project_title %}
-  {% include components/case-study-block.html item=item heading_level="h3" %}
-  {% assign case_study_titles = case_study_titles | append: item.project_title %}
-  {% assign block_count = block_count | plus:1 %}
-  {% endunless %}
-  {% endif %}
-  {% endfor %}
-  {% endfor %}
-</div>
+{% comment %} Prints small case study blocks for related case studies, limit specified in include statement. {% endcomment %}
+{% assign items = site.case-studies | sort: 'weight' %}
+{% assign block_count = 0 %}
+{% assign case_study_titles = '' %}
+{% for item in items %}
+{% for tag in include.tags %}
+{% if item.tags contains tag and block_count < include.limit %}
+{% unless case_study_titles contains item.project_title %}
+{% include components/case-study-block.html item=item heading_level="h3" %}
+{% assign case_study_titles = case_study_titles | append: item.project_title %}
+{% assign block_count = block_count | plus:1 %}
+{% endunless %}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,13 +47,17 @@ layout: default
     <div class="region--post-aside__section__wrapper--posts">
       <div class="region--post-aside__section region--post-aside__section--posts">
         <h2 class="heading--sans-serif c-grey h3">Related Blog Posts</h2>
-        {% include regions/blog-tiles--related--post.html tags=page.tags limit=2 %}
+        <div class="region--post-aside__section__items region--post-aside__section--posts__items">
+          {% include regions/blog-tiles--related--post.html tags=page.tags limit=2 %}
+        </div>
       </div>
     </div>
     <div class="region--post-aside__section__wrapper--case-studies">
       <div class="region--post-aside__section region--post-aside__section--case-studies">
         <h2 class="heading--sans-serif c-grey h3">Related Case Studies</h2>
-        {% include regions/case-study-blocks--related--post.html tags=page.tags limit=2 %}
+        <div class="region--post-aside__section__items region--post-aside__section--posts__items">
+          {% include regions/case-study-blocks--related--post.html tags=page.tags limit=2 %}
+        </div>
         <div class="region--post-aside__section--case-studies__cta flex-center">
           <a href="/results" class="button--arrow--orange">Our work</a>
         </div>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+class: "page--tag"
 ---
 
 {% comment %} Find the name of this tag page. {% endcomment %}
@@ -26,18 +27,24 @@ layout: default
 
 {% comment %} If so, output the top-weighted three. {% endcomment %}
 {% if related_case_studies > 0 %}
-<div class="tag__related-case-studies">
+<div class="tag__related-case-studies region--case-study-blocks region--case-study-blocks--small region">
   <h2 class="heading--underline--orange">Related Case Studies</h2>
-  {% include regions/case-study-blocks--related--post.html tags=page.tag limit=3 %}
+  <div class="region--case-study-blocks__case-studies">
+    {% include regions/case-study-blocks--related--post.html tags=page.tag limit=3 %}
+  </div>
 </div>
 <div class="view-more-link">
-  <a href="/work" class="button--arrow--orange">View all case studies</a>
+  <a href="/results/case-studies">View all case studies</a>
 </div>
 <hr>
 {% endif %}
 
-<div class="tag__related-posts">
+<div class="tag__related-posts region--blog-tiles--all region">
   <h2 class="heading--underline--orange">Related Blog Posts</h2>
-  {% include regions/blog-tiles--related--post.html tags=page.tag limit=8 %}
-  <a href="/blog" class="link--arrow">View all blog</a>
+  <div class="region--blog-tiles--all__tiles">
+    {% include regions/blog-tiles--related--post.html tags=page.tag limit=8 %}
+  </div>
+  <div class="flex-center">
+    <a href="/blog" class="link--arrow">View all blog</a>
+  </div>
 </div>

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -3,50 +3,50 @@ layout: default
 title: Contact
 permalink: "/contact/"
 excerpt: All the ways to contact Savas Labs
+class: "page--contact"
 ---
-<div class="region">
-  <div class="page--contact__copy">
-    <h1 class="heading--underline--orange">Contact Us</h1>
-    <p>Interested in working together? Planning a project and need a team to help you see it through?<br>
-      Reach out to us and we will follow up to schedule a time to talk.</p>
-    <table class="table--minimal table--minimal--contact">
-      <tbody>
-      <tr>
-        <td class="table-minimal--contact__label">
-          <p>Email</p>
-        </td>
-        <td><a href="mailto:info@savaslabs.com">info@savaslabs.com</a></td>
-      </tr>
-      <tr>
-        <td class="table-minimal--contact__label">
-          <p>Phone</p>
-        </td>
-        <td>(919) 432-4660</td>
-      </tr>
-      <tr>
-        <td class="table-minimal--contact__label">
-          <p>Twitter</p>
-        </td>
-        <td><a href="https://twitter.com/savas_labs">@savas_labs</a></td>
-      </tr>
-      <tr>
-        <td class="table-minimal--contact__label">
-          <p>Durham office</p>
-        </td>
-        <td>Savas Labs<br>
-          PMB 210<br>
-          201 W Main Street, Suite 100<br>
-          Durham, NC 27701<br>
-        </td>
-      </tr>
-      </tbody>
-    </table>
-    <a href="/results" class="button--arrow--orange">Explore our work</a>
-  </div>
-  <div class="page--contact__image">
-    <img src="/assets/img/bg/contact-hero.jpg" alt="Chris Russo of Savas Labs at a client meeting">
+<div class="page--contact__content region">
+  <h1 class="heading--underline--orange">Contact Us</h1>
+  <div class="page--contact__content-wrapper">
+    <div class="page--contact__copy">
+      <p>Interested in working together? Planning a project and need a team to help you see it through?<br>
+        Reach out to us and we will follow up to schedule a time to talk.</p>
+      <table class="table--minimal table--minimal--contact">
+        <tbody>
+        <tr class="table--minimal__first-row">
+          <td class="table--minimal--contact__label table--minimal__first-column">
+            Email
+          </td>
+          <td><a href="mailto:info@savaslabs.com">info@savaslabs.com</a></td>
+        </tr>
+        <tr>
+          <td class="table--minimal--contact__label table--minimal__second-column">
+            Phone
+          </td>
+          <td>(919) 432-4660</td>
+        </tr>
+        <tr>
+          <td class="table--minimal--contact__label">
+            Twitter
+          </td>
+          <td><a href="https://twitter.com/savas_labs">@savas_labs</a></td>
+        </tr>
+        <tr>
+          <td class="table--minimal--contact__label">
+            Durham office
+          </td>
+          <td>Savas Labs<br>
+            PMB 210<br>
+            201 W Main Street, Suite 100<br>
+            Durham, NC 27701<br>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="page--contact__image">
+      <img src="/assets/img/bg/contact-hero.jpg" alt="Chris Russo of Savas Labs at a client meeting">
+      <a href="/results" class="link--arrow">Explore our work</a>
+    </div>
   </div>
 </div>
-
-
-


### PR DESCRIPTION
This is based on my open source page branch, so it'll need to be rebased once that is merged.

This styles the tag pages, and refactors the blog tiles styles to use `width` rather than `flex-basis`. This became necessary when there are odd numbers of tiles on tag pages to maintain the tiles' width when there isn't a full row of them.

This also styles the contact page. Question - what do you think about this on very large screens, above 1440px? Is there too much space between the table and the image?