### PR TITLE
Issue #3352: Add number of comments to expander text

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -75,6 +75,7 @@ $(document).ready(
                         commentString = 'comment';
                     }
                     $("#comment-count").html('<a href="#js-expander-trigger"><i class="fa fa-comment"></i>' + json.data[0][truncatedSlug] + ' ' + commentString + '</a>');
+                    $('#comments-trigger').html('Comments (' + json.data[0][truncatedSlug] + ')');
                 }
             });
     });

--- a/_includes/regions/comments.html
+++ b/_includes/regions/comments.html
@@ -4,7 +4,7 @@
   {% else %}
   <div class="expander">
     <a href="javascript:void(0)" id="js-expander-trigger" class="expander-trigger expander--hidden">
-      <p>Comments</p>
+      <p id="comments-trigger">Comments</p>
     </a>
     <div id="js-expander-content" class="expander-content region">
 


### PR DESCRIPTION
Hey @oksana-c,

This adds the number of comments to the expander trigger at the bottom of blog posts, resolving [issue 3352](https://pm.savaslabs.com/issues/3352).

You can test this locally by opening up `_config.dev.yml` and changing the comment server url line to:

```
comment_server_url: "http://comments.savaslabs.com"
```

Then the comments from the live site will appear for you locally so you can look at a few posts with comments (e.g. http://localhost:3000/2016/10/19/optimizing-jekyll-with-gulp.html and http://localhost:3000/2016/11/15/composer-mailchimp-subscriptions-v3-api.html) and a few with no comments. Just don't leave any test comments or they'll end up on the live site 😸 