### PR TITLE
Task #3369: Homepage hero region VH tweak

### DIFF
--- a/_assets/styles/scss/04-components/_image--hero--home.scss
+++ b/_assets/styles/scss/04-components/_image--hero--home.scss
@@ -27,7 +27,7 @@
 
   @include grid-media($extra-large-screen-up) {
     height: 100vh;
-    min-height: 800px;
+    min-height: 600px;
   }
 
   .home__cover__heading,


### PR DESCRIPTION
Hey @AnneTee, this PR reduces min-height of the homepage hero region to 600px on `medium-screen-up` viewports. Min height is still needed because some hi-res smartphones in landscape mode will overlap absolutely positioned elements (`.home__cover__content`) over the positioning statement. Since the CTA button is removed from the homepage cover now - we can lower min-height, but if it's added back in the future, we'll have to revisit this again. Please test.