### PR TITLE
Issue #3355: Show 9 blog tiles on tag pages

### DIFF
--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -42,7 +42,7 @@ class: "page--tag"
 <div class="tag__related-posts region--blog-tiles--all region">
   <h2 class="heading--underline--orange">Blog Posts about {{ tag }}</h2>
   <div class="region--blog-tiles--all__tiles">
-    {% include regions/blog-tiles--related--post.html tags=page.tag limit=8 %}
+    {% include regions/blog-tiles--related--post.html tags=page.tag limit=9 %}
   </div>
   <div class="flex-center">
     <a href="/blog" class="link--arrow">View all blog</a>


### PR DESCRIPTION
@oksana-c This updates the tag pages to show a max of 9 blog tiles rather than 8. "Load more" feature to be implemented!

To test, check out http://localhost:3000/blog/tag/drupal8/ and http://localhost:3000/blog/tag/drupal/