### PR TITLE
Issue #3382: Style arrow buttons on small screens

### DIFF
--- a/_assets/styles/scss/01-base/_mixins.scss
+++ b/_assets/styles/scss/01-base/_mixins.scss
@@ -143,13 +143,18 @@
   color: $color;
   display: inline-block;
   font-family: $copytext-font;
-  font-size: 1.25em;
+  font-size: 1em;
   height: 64px;
   line-height: 60px;
-  padding: 0 90px 0 30px;
+  padding: 0 70px 0 10px;
   position: relative;
   text-align: center;
   transition: background-color .2s ease-in-out, color .2s ease-in-out, border-color .2s ease-in-out;
+
+  @include grid-media($medium-screen-up) {
+    font-size: 1.25em;
+    padding: 0 90px 0 30px;
+  }
 
   &::after {
     background-color: $color;


### PR DESCRIPTION
@oksana-c This sets the font size and padding to smaller values below 640px for arrow buttons. I'm assuming here that the "Start the conversation" button on the home page (and others) is the longest text we'd include on a button like this.