### PR TITLE
Issue #3385: Remove underline from heading on tag pages

### DIFF
--- a/_assets/styles/scss/06-pages/_blog.scss
+++ b/_assets/styles/scss/06-pages/_blog.scss
@@ -7,6 +7,10 @@
 .page--blog {
   .region--banner--heading {
     margin-bottom: 6px;
+
+    h1 {
+      @include heading-underline($orange);
+    }
   }
 
   .page--blog__wrapper {

--- a/_includes/regions/banner--heading.html
+++ b/_includes/regions/banner--heading.html
@@ -1,7 +1,7 @@
 <div class="region--banner region--banner--heading region--full-width bg-teal">
   <div class="region--full-width__wrapper">
     <div class="region--banner--heading__text">
-      <h1 class="heading--underline--orange heading--bold c-eggshell">{{ include.heading }}</h1>
+      <h1 class="heading--bold c-eggshell">{{ include.heading }}</h1>
       {% if include.subheading %}
       <p class="c-eggshell h3">{{ include.subheading }}</p>
       {% endif %}


### PR DESCRIPTION
@oksana-c This removes the h1 underline on tag pages (but not the main blog page)!