### PR TITLE
Issue #3424: Disable comments for Squabble post

### DIFF
--- a/_posts/2016-04-20-squabble-comments.md
+++ b/_posts/2016-04-20-squabble-comments.md
@@ -5,6 +5,9 @@ date: 2016-04-20
 author: Kosta Harlan
 tags: jekyll javascript
 services: development
+comments_enabled: 0
+disclaimer: |
+    Due to numerous "Just testing this" type comments, we've disabled comments on this post. But we hope you do test this comment system out on your own site!
 summary: |
   A peek under the hood at our website's commenting app, Squabble.
 ---


### PR DESCRIPTION
<img width="893" alt="image" src="https://cloud.githubusercontent.com/assets/208893/25859445/18823454-34ce-11e7-9082-d90f0ca6e2d1.png">

@AnneTee this disables comments on the Squabble post. What do you think of the wording?