### PR TITLE
Issue #3449: Add list styles to critical CSS for posts

### DIFF
--- a/_assets/styles/critical--post.scss
+++ b/_assets/styles/critical--post.scss
@@ -12,6 +12,7 @@
 // Typography rules.
 @import 'scss/03-typography/headings';
 @import 'scss/03-typography/links';
+@import 'scss/03-typography/lists';
 @import 'scss/03-typography/paragraphs';
 
 // Component rules.


### PR DESCRIPTION
This overrides the baseline list styles which is to remove the list-style-type. To test:

- Check out [this post on the live site](http://savaslabs.com/2015/06/10/d8-theming-basics.html). You'll see a bunch of lists with no bullets.
- Pull this code and run `gulp serve`. Look at the post [locally](http://localhost:3000/2015/06/10/d8-theming-basics.html) and confirm that the lists now have square bullets
- Check some other blog posts to make sure ordered and unordered lists have the correct list style type (numerals for ordered, squares for unordered)

There aren't any other places on the site other than blog posts where we're using bulleted lists so reviewing the blog posts should be sufficient.