### PR TITLE
Issue #3450: fix detailed blog tile hover width

### DIFF
--- a/_assets/styles/critical--tag.scss
+++ b/_assets/styles/critical--tag.scss
@@ -16,6 +16,7 @@
 @import 'scss/03-typography/paragraphs';
 
 // Component rules.
+@import 'scss/04-components/buttons--arrow';
 @import 'scss/04-components/case-study-block';
 @import 'scss/04-components/header-navigation';
 @import 'scss/04-components/header-navigation--menu-link';
@@ -26,3 +27,6 @@
 @import 'scss/05-regions/case-study-blocks';
 @import 'scss/05-regions/case-study-blocks--small';
 @import 'scss/05-regions/header';
+
+// Page rules.
+@import 'scss/06-pages/tag';

--- a/_assets/styles/critical--tag.scss
+++ b/_assets/styles/critical--tag.scss
@@ -21,9 +21,14 @@
 @import 'scss/04-components/header-navigation';
 @import 'scss/04-components/header-navigation--menu-link';
 @import 'scss/04-components/logos';
+@import 'scss/04-components/tiles';
+@import 'scss/04-components/tiles--blog';
+@import 'scss/04-components/tiles--blog--detailed';
 
 // Region rules.
 @import 'scss/05-regions/banner--heading';
+@import 'scss/05-regions/blog-tiles';
+@import 'scss/05-regions/blog-tiles--all';
 @import 'scss/05-regions/case-study-blocks';
 @import 'scss/05-regions/case-study-blocks--small';
 @import 'scss/05-regions/header';

--- a/_assets/styles/scss/04-components/_tiles--blog--detailed.scss
+++ b/_assets/styles/scss/04-components/_tiles--blog--detailed.scss
@@ -94,7 +94,7 @@ parent: tiles
     }
   }
 
-  .tile--blog__hover {
+  &.tile--blog .tile--blog__hover {
     margin: 1em;
     width: calc(100% - 2em);
   }

--- a/_assets/styles/scss/06-pages/_tag.scss
+++ b/_assets/styles/scss/06-pages/_tag.scss
@@ -5,8 +5,14 @@
  */
 
 .page--tag {
+  .tag__related-case-studies {
+    padding-bottom: 0;
+  }
+
   .view-more-link a {
     @include link-arrow;
+
+    margin-bottom: $base-margin;
 
     @include grid-media($medium-screen-up) {
       @include button-arrow($white, $orange);

--- a/_assets/styles/scss/06-pages/_team.scss
+++ b/_assets/styles/scss/06-pages/_team.scss
@@ -282,6 +282,11 @@
       @include grid-media($large-screen-up) {
         width: 25%;
       }
+
+      .tile--blog__hover {
+        margin: $base-spacing / 4;
+        width: calc(100% - .5em);
+      }
     }
   }
 }

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -33,7 +33,7 @@ class: "tag"
     {% include regions/case-study-blocks--related--post.html tags=page.tag limit=3 %}
   </div>
 </div>
-<div class="view-more-link">
+<div class="view-more-link flex-center">
   <a href="/results/case-studies">View all case studies</a>
 </div>
 <hr>


### PR DESCRIPTION
The style setting the width of the blog tile hover content for detailed blog tiles wasn't specific enough, so I added an item to the selector to fix that. This affects blog tiles on /blog and tag pages.

To test:

- Check out http://savaslabs.com/blog/ and http://savaslabs.com/blog/tag/drupal/. Hover over the blog tiles to see the hover state, which is too wide. You'll also notice on the tag page that the arrow button layout is off (it should be centered).
- Pull this branch and run `gulp serve`
- View the [blog page](http://localhost:3000/blog/) and a [tag page](http://localhost:3000/blog/tag/theming/) locally to test the hover state of the blog tiles. Test at various screen widths. On the tag page, ensure the arrow button is centered and spaced correctly.
- Also check out the blog tiles on the following pages, which should remain unaffected:
  - [Home](http://localhost:3000/)
  - [Service page](http://localhost:3000/services/strategy/)
  - [Blog post](http://localhost:3000/2017/04/24/savas-labs-website-redesign.html)
  - [Team member page](http://localhost:3000/company/anne-tomasevich/)
