### PR TITLE
Issue #3386: Set Blog to active nav item on posts

### DIFF
--- a/_includes/components/navigation--header.html
+++ b/_includes/components/navigation--header.html
@@ -7,10 +7,10 @@
     {% for link in site.data.navigation %}
       {% comment %} Assign active nav item class. {% endcomment %}
       {% assign active-nav-item = nil %}
-      {% if page.url contains link.url %}
-        {% assign active-nav-item = 'header-navigation__active-nav-item' %}
+      {% if (page.url contains link.url) or (link.title == "Blog" and page.path contains "_posts") %}
+        {% assign active-nav-item = ' header-navigation__active-nav-item' %}
       {% endif %}
-      <li class="header-navigation__menu-link {{ active-nav-item }}">
+      <li class="header-navigation__menu-link{{ active-nav-item }}">
         <a href="{{ link.url }}">{{ link.title }}</a>
       </li>
     {% endfor %}


### PR DESCRIPTION
Fixes issue [#3386](https://pm.savaslabs.com/issues/3386)

## Summary of changes

1. Sets the "Blog" nav item to active on post pages so "Blog" will appear highlighted
2. Adjusts the code a little to only add a space in the markup if needed. See image. Yes this is important stuff.

![pic](https://user-images.githubusercontent.com/8465998/29252522-099fed3c-8037-11e7-92d5-b05d2b69cbbf.png)

## To test

- [x] Pull this and run `gulp clean` then `gulp serve`
- [x] Visit a post page and make sure the Blog nav item is highlighted with magenta and has the `header-navigation__active-nav-item` class
- [x] Ensure the proper active nav item is highlighted on other pages

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment
