### PR TITLE
Issue #4432: Set footer icon list style type to none

### DIFF
--- a/_assets/styles/scss/05-regions/_footer.scss
+++ b/_assets/styles/scss/05-regions/_footer.scss
@@ -174,6 +174,7 @@ category: Regions
       }
 
       li {
+        list-style-type: none;
         padding: 0 $footer-padding / 4;
 
         &:last-child {


### PR DESCRIPTION
Fixes issue [#4432](https://pm.savaslabs.com/issues/4432)

## Summary of changes

1. Explicitly sets the `list-style-type` of footer icons to `none` to avoid this, which is only happening on blog pages:

![screen shot 2017-08-24 at 12 12 24 pm](https://user-images.githubusercontent.com/8465998/29676241-83a8c2ca-88c5-11e7-8faf-c828828e9f35.png)

This is happening because the CSS reset styles in `normalize.css` are being overridden by our list styles in `_lists.scss`, both of which are getting inlined in the HTML `<head>` as critical CSS. Big shoutout to the "cascading" part of CSS for this one! (It is actually my fault; sorry CSS.)

## To test

- [x] Pull this and run `gulp clean` then `gulp serve`
- [x] Check the footer on multiple pages, especially blog posts. You should not see list bullets next to the icons.

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment
