### PR TITLE
Issue #3945: Update Squabble endpoint

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: >
 # not used at all.
 baseurl: ""
 url: "https://savaslabs.com"
-comment_server_url: "http://comments.savaslabs.com"
+comment_server_url: "https://squabble.savaslabs.com"
 comment_server_enabled: 1
 
 # Professional and social media links


### PR DESCRIPTION
Fixes issue [#3945](https://pm.savaslabs.com/issues/3945)

## Summary of changes

1. Update the endpoint to the new location of the Squabble comment server, now served over HTTPS

## To test

- [ ] Deploy it!

If you want to check locally, you can adjust your dev YML file and set it to point to `https://squabble.savaslabs.com`.

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
