### PR TITLE
Update typography styles on blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,22 @@ pixels to satisfy Google's structured data requirements.
 
 #### Image placement and size within the post body
 
+You can add images with the following markdown syntax:
+
+```
+![Image alt text here]({{ site.url }}/assets/img/blog/image-name.jpg){:class="blog-image-full-width"}
+```
+
 You can add following classes to contextual images:
-- class="blog-image-full-width" - image will span the whole width of the post
-- class="blog-image-left" - image will float left
-- class="blog-image-right" - image will float right
+- `class="blog-image-full-width"` - image will span the whole width of the post
+- `class="blog-image-left"` - image will float left
+- `class="blog-image-right"` - image will float right
 
 Images without class will use default styling which is 100% post width.
 
 Captions can be added to full width images by adding `<span class="caption">Caption</span>` right under the image tag.
 
-To add caption to floated images wrap <IMG> tag in a div and give it a class. E.g.
+To add caption to floated images wrap <img> tag in a div and give it a class. E.g.
 
 ``` html
 <div class="blog-image-left">

--- a/_assets/styles/scss/01-base/_variables.scss
+++ b/_assets/styles/scss/01-base/_variables.scss
@@ -20,6 +20,7 @@
 $copytext-font: 'Roboto Condensed', Arial Narrow, Arial, sans-serif;
 $heading-font: 'Roboto Slab', Verdana, sans-serif;
 $monospace-font: Menlo, Monaco, 'Andale Mono', 'lucida console', 'Courier New', monospace !default;
+$post-font: 'Roboto', Helvetica Neue, Helvetica, Arial, sans-serif;
 
 // Spacing and other utilities -------------------------------------------------
 $max-width: 1440px;
@@ -130,5 +131,5 @@ $solar-green:     $green;
 
 // Non highlighted code colors.
 $pre-bg: $base03 !default;
-$pre-border: darken($base01, 5) !default;
+$pre-border: darken($base01, 20) !default;
 $pre-color: $base1 !default;

--- a/_assets/styles/scss/03-typography/_blockquote.scss
+++ b/_assets/styles/scss/03-typography/_blockquote.scss
@@ -72,3 +72,8 @@ blockquote {
     }
   }
 }
+
+// In blog posts, align blockquote text left for better readability.
+.region--post-content blockquote p {
+  text-align: left;
+}

--- a/_assets/styles/scss/03-typography/_lists.scss
+++ b/_assets/styles/scss/03-typography/_lists.scss
@@ -53,7 +53,9 @@ ul ol li,
 ol ul,
 ol ul li,
 ol ol,
-ol ol li {
+ol ol li,
+ul p,
+ol p {
   font-size: 1em !important;
 }
 // scss-lint:enable ImportantRule

--- a/_assets/styles/scss/04-components/_blog-topic.scss
+++ b/_assets/styles/scss/04-components/_blog-topic.scss
@@ -94,7 +94,6 @@ category: Regions
 
 .blog-topic__link {
   @include ease;
-  // background-color: $eggshell;
   border-bottom: 1px solid $gainsboro;
   display: block;
   margin: 0 1.25em .5em 0;

--- a/_assets/styles/scss/04-components/_footnotes.scss
+++ b/_assets/styles/scss/04-components/_footnotes.scss
@@ -9,8 +9,12 @@
   margin-top: 3em;
   padding-top: .5em;
 
+  // scss-lint:disable ImportantRule
   p,
-  li {
-    font-size: 1em;
+  li,
+  ol,
+  ul {
+    font-size: 1em !important;
   }
+  // scss-lint:disable ImportantRule
 }

--- a/_assets/styles/scss/04-components/_images--blog-post.scss
+++ b/_assets/styles/scss/04-components/_images--blog-post.scss
@@ -14,6 +14,9 @@
 
 .blog-image {
   display: block;
+
+  // Set font size to what is normally 1em for spacing purposes.
+  font-size: .888em;
   margin: 1em auto;
   max-width: 250px;
   width: 100%;
@@ -50,14 +53,33 @@
   max-width: none;
   width: calc(100% + 2em);
 
+  // The following styles make full width images span the width of the article
+  // container, even though the text body may be less wide to maintain
+  // readability. See _post.scss for corresponding styles on
+  // .region--post-content.
   @include grid-media($medium-screen-up) {
-    margin-left: -$base-spacing * 1.5;
+    margin-left: -1.5em;
     width: calc(100% + 3em);
   }
 
   @include grid-media($extra-large-screen-up) {
-    margin-left: -$base-spacing * 2;
-    width: calc(100% + 4em);
+    margin-left: -4em;
+    width: calc(100% + 8em);
+  }
+
+  @media (min-width: 1280px) {
+    margin-left: -5em;
+    width: calc(100% + 10em);
+  }
+
+  @media (min-width: 1360px) {
+    margin-left: -7em;
+    width: calc(100% + 14em);
+  }
+
+  @include grid-media($max-width-up) {
+    margin-left: -8em;
+    width: calc(100% + 16em);
   }
 }
 
@@ -70,14 +92,30 @@
   max-width: none;
   width: calc(100% + 2em);
 
+  // On larger screens, image should touch left side of container.
   @include grid-media($medium-screen-up) {
     margin-left: -$base-spacing * 1.5;
     width: calc(50% + 1.5em);
   }
 
   @include grid-media($extra-large-screen-up) {
-    margin-left: -$base-spacing * 2;
-    width: calc(50% + 2em);
+    margin-left: -$base-spacing * 4;
+    width: calc(50% + 4em);
+  }
+
+  @media (min-width: 1280px) {
+    margin-left: -5em;
+    width: calc(50% + 5em);
+  }
+
+  @media (min-width: 1360px) {
+    margin-left: -7em;
+    width: calc(50% + 7em);
+  }
+
+  @include grid-media($max-width-up) {
+    margin-left: -8em;
+    width: calc(50% + 8em);
   }
 }
 
@@ -90,14 +128,30 @@
   max-width: none;
   width: calc(100% + 2em);
 
+  // On larger screens, image should touch right side of container.
   @include grid-media($medium-screen-up) {
     margin-right: -$base-spacing * 1.5;
     width: calc(50% + 1.5em);
   }
 
   @include grid-media($extra-large-screen-up) {
-    margin-right: -$base-spacing * 2;
-    width: calc(50% + 2em);
+    margin-right: -$base-spacing * 4;
+    width: calc(50% + 4em);
+  }
+
+  @media (min-width: 1280px) {
+    margin-right: -5em;
+    width: calc(50% + 5em);
+  }
+
+  @media (min-width: 1360px) {
+    margin-right: -7em;
+    width: calc(50% + 7em);
+  }
+
+  @include grid-media($max-width-up) {
+    margin-right: -8em;
+    width: calc(50% + 8em);
   }
 }
 
@@ -107,19 +161,4 @@
   font-size: .9em;
   margin: 0 auto 2em;
   text-align: center;
-}
-
-.blog-image-left .caption,
-.blog-image-right .caption {
-  margin-bottom: 0;
-  padding: $base-spacing / 2 $base-spacing;
-  text-align: left;
-
-  @include grid-media($medium-screen-up) {
-    padding: $base-spacing / 2 $base-spacing * 1.5;
-  }
-
-  @include grid-media($extra-large-screen-up) {
-    padding: $base-spacing / 2 $base-spacing * 2;
-  }
 }

--- a/_assets/styles/scss/06-pages/_post.scss
+++ b/_assets/styles/scss/06-pages/_post.scss
@@ -37,20 +37,30 @@
     }
 
     .region--post-header {
-      h1 {
+      margin: $base-margin 0;
+
+      .region--post-header__title {
         font-weight: 400;
+        margin-bottom: 1.5em;
       }
     }
 
     .region--post-content {
       color: $dark-teal;
+      word-wrap: break-word;
+
+      // Set a max-width to post text so line length stays reasonable.
+      // This is the width of the post text below the extra large breakpoint.
+      @include grid-media($extra-large-screen-up) {
+        margin: 0 auto;
+        width: 728px;
+      }
 
       h2,
       h3,
       h4,
       h5,
       h6 {
-        font-family: $copytext-font;
         font-weight: 400;
       }
 
@@ -58,6 +68,21 @@
         color: $grey;
         font-style: italic;
       }
+
+      p,
+      ol,
+      ul {
+        font-family: $post-font;
+        font-size: 1.125em;
+        line-height: 1.625;
+        margin-bottom: 1em;
+      }
+
+      li {
+        margin-bottom: .325em;
+      }
+
+
     }
   }
 
@@ -92,15 +117,6 @@
 
   .region--footer {
     margin-top: 0;
-  }
-}
-
-// Post header.
-.region--post-header {
-  margin: $base-margin 0;
-
-  .region--post-header__title {
-    margin-bottom: 1.5em;
   }
 }
 

--- a/_assets/styles/scss/06-pages/_post.scss
+++ b/_assets/styles/scss/06-pages/_post.scss
@@ -30,14 +30,14 @@
       @include grid-media($medium-screen-up) {
         padding: 0 $base-spacing * 1.5;
       }
-
-      @include grid-media($extra-large-screen-up) {
-        padding-right: $base-spacing * 2;
-      }
     }
 
     .region--post-header {
       margin: $base-margin 0;
+
+      @include grid-media($extra-large-screen-up) {
+        padding-right: $base-spacing * 2;
+      }
 
       .region--post-header__title {
         font-weight: 400;
@@ -49,11 +49,23 @@
       color: $dark-teal;
       word-wrap: break-word;
 
-      // Set a max-width to post text so line length stays reasonable.
-      // This is the width of the post text below the extra large breakpoint.
+      // Add left & right padding to post body on large screens to keep text
+      // width at a readable level, 680-730px. See _images--blog-post.scss for
+      // corresponding styles on .blog-image-full-width.
       @include grid-media($extra-large-screen-up) {
-        margin: 0 auto;
-        width: 728px;
+        padding: 0 4em;
+      }
+
+      @media only screen and (min-width: 1280px) {
+        padding: 0 5em;
+      }
+
+      @media only screen and (min-width: 1360px) {
+        padding: 0 7em;
+      }
+
+      @include grid-media($max-width-up) {
+        padding: 0 8em;
       }
 
       h2,

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,7 +25,7 @@
   <script>
     !function(e){"use strict";var t=function(t,n,r){function o(e){return i.body?e():void setTimeout(function(){o(e)})}function l(){d.addEventListener&&d.removeEventListener("load",l),d.media=r||"all"}var a,i=e.document,d=i.createElement("link");if(n)a=n;else{var s=(i.body||i.getElementsByTagName("head")[0]).childNodes;a=s[s.length-1]}var u=i.styleSheets;d.rel="stylesheet",d.href=t,d.media="only x",o(function(){a.parentNode.insertBefore(d,n?a:a.nextSibling)});var f=function(e){for(var t=d.href,n=u.length;n--;)if(u[n].href===t)return e();setTimeout(function(){f(e)})};return d.addEventListener&&d.addEventListener("load",l),d.onloadcssdefined=f,f(l),d};"undefined"!=typeof exports?exports.loadCSS=t:e.loadCSS=t}("undefined"!=typeof global?global:this),function(e){if(e.loadCSS){var t=loadCSS.relpreload={};if(t.support=function(){try{return e.document.createElement("link").relList.supports("preload")}catch(t){}},t.poly=function(){for(var t=e.document.getElementsByTagName("link"),n=0;n<t.length;n++){var r=t[n];"preload"===r.rel&&"style"===r.getAttribute("as")&&(e.loadCSS(r.href,r),r.rel=null)}},!t.support()){t.poly();var n=e.setInterval(t.poly,300);e.addEventListener&&e.addEventListener("load",function(){e.clearInterval(n)})}}}(this);
     loadCSS('/assets/styles/main.css');
-    loadCSS('https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700|Roboto+Slab:300,400');
+    loadCSS('https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700|Roboto+Slab:300,400|Roboto:400,400i,700,700i');
   </script>
 
   <!-- Inline critical CSS. -->

--- a/_posts/2016-05-20-drupalcon-nola-recap.md
+++ b/_posts/2016-05-20-drupalcon-nola-recap.md
@@ -7,7 +7,7 @@ tags: drupal drupal8 conference event
 summary: The ins and outs of the talks, sessions, parties, and more from Drupalcon New Orleans 2016.
 ---
 
-<img src="/assets/img/blog/drupalcon-nola.jpg" alt="Drupalcon New Orleans logo">
+<img src="/assets/img/blog/drupalcon-nola.jpg" alt="Drupalcon New Orleans logo" class="blog-image-full-width">
 
 A week full of summits, sessions, a presentation, some parties and a fair amount of tweeting <img src="/assets/img/icons-and-logos/twitter-bird.svg" height="24" alt="Twitter bird"> was one for the books at Drupalcon NOLA 2016. Come along for a Twitter-assisted chronological journey for Savas Labs in New Orleans.
 
@@ -15,7 +15,7 @@ A week full of summits, sessions, a presentation, some parties and a fair amount
 
 I arrived Saturday evening after a few short flights from Durham, NC. My gracious host and boots on the ground in NOLA Kevin Harrison lent me a bicycle, showed me around the city, and invited me to play in his soccer game. It was a comforting entry into a new city that closely resembled what my weekend would have been like if I were at home. Thanks a ton Kevin for the hospitality!
 
- <img src="/assets/img/blog/kevin-harrison.jpg" alt="Kevin at a rooftop bar">
+ <img src="/assets/img/blog/kevin-harrison.jpg" alt="Kevin at a rooftop bar" class="blog-image-full-width">
  <span class="caption">See a palindrome anywhere?</span>
 
  Kevin also took me to the convention center so I could get my bearings for the week ahead. He took my picture, and **_ever so slightly_** doctored up the version you see below for me to share with our community that we had made it to the big stage!

--- a/_posts/2016-05-26-installing-xhprof.md
+++ b/_posts/2016-05-26-installing-xhprof.md
@@ -39,7 +39,7 @@ sudo apt-get install php5-dev
 
 And, if you want to view nice callgraph trees like the one below you'll need to install the graphviz package `sudo apt-get install graphviz`
 
-<img src="/assets/img/blog/xhprof-callgraph.jpg" alt="Image of a sample XHProf callgraph">
+<img src="/assets/img/blog/xhprof-callgraph.jpg" alt="Image of a sample XHProf callgraph" class="blog-image-full-width">
 
 ## Configure PHP to run XHProf
 
@@ -138,7 +138,7 @@ Note: Another way to run XHProf on a Drupal site is using the [XHProf](https://w
 
 If everything is configured correctly, when you run your module you should get a run ID output either to the screen (via `echo`, as above, or however you've configured this logging). Visit the URL you configured above for xhprof, and you should see a list of all the stored runs. Clicking on a run will bring up the full profiler report.
 
-<img src="/assets/img/blog/xhprof-screenshot.jpg" alt="Sample screenshot of an XHProf profiler report">
+<img src="/assets/img/blog/xhprof-screenshot.jpg" alt="Sample screenshot of an XHProf profiler report" class="blog-image-full-width">
 
 ## Now what?
 

--- a/_posts/2016-06-15-git-merge-conflict-strategies.md
+++ b/_posts/2016-06-15-git-merge-conflict-strategies.md
@@ -84,7 +84,7 @@ A good visual merge tool will display at least 3 panels for each file with confl
 
 I prefer merge tools (such as the P4Merge tool shown below) which also include a fourth display panel showing the version of that file in the merge base:
 
-<img src="/assets/img/blog/P4Merge_screenshot.jpg" alt="P4Merge tool screenshot">
+<img src="/assets/img/blog/P4Merge_screenshot.jpg" alt="P4Merge tool screenshot" class="blog-image-full-width">
 
 There are many visual merge tools to choose from, some of which may already be installed on your system.
 

--- a/_posts/2016-06-16-using-xhprof.md
+++ b/_posts/2016-06-16-using-xhprof.md
@@ -22,7 +22,7 @@ The XHProf GUI displays the result of a given profiler run, or a group of runs. 
 
 You can also go directly to a specific run report via the URL `<my-local-site>/xhprof/index.php?run=<run-id>&source=<source-id>` (which you should have been logging already via an `echo` statement or `dblog` if you followed the last post).
 
-<img src="/assets/img/blog/xhprof-results-page-screenshot.jpg" alt="Header of an XHProf run report">
+<img src="/assets/img/blog/xhprof-results-page-screenshot.jpg" alt="Header of an XHProf run report" class="blog-image-full-width">
 
 The core of the run report is a table of each function or method which your code called while it was being profiled, along with a set of statistics about that function. This allows you to understand which parts of your code are most resource-intensive, and which are being called frequently in the use case that you're profiling. Clicking on any one of the column headers will sort the list by that metric. To understand this report, it's helpful to have some terminology:
 
@@ -44,7 +44,7 @@ Now it's time to get organized. Write a simple test script so that you can easil
 
 Keeping your different runs organized is probably the most important part of successfully profiling module code using XHProf! Each run has a unique run ID, but **you** are solely responsible for knowing which use case scenario and which version of the codebase that run ID corresponds to. I set up a basic spreadsheet in OpenOffice where I could paste in run numbers and basic run stats to compare (but there's almost certainly a nicer automated way to do this than what I used).
 
-<img src="/assets/img/blog/xhprof-results-spreadsheet.jpg" alt="Screenshot of an OpenOffice spreadsheet summarizing XHProf results for various runs">
+<img src="/assets/img/blog/xhprof-results-spreadsheet.jpg" alt="Screenshot of an OpenOffice spreadsheet summarizing XHProf results for various runs" class="blog-image-full-width">
 
 Once you have a set of run IDs for a given use case + codebase version, you can generate a *composite* xhprof report using the query string syntax `http://<your-local-site>/xhprof/index.php?run=<first-run-id>,<second-run-id>,<third-run-id>&source=<source-string>` Averaging out across a few runs should give you more [precise](https://en.wikipedia.org/wiki/Accuracy_and_precision) measurements for CPU time and memory usage, but beware that if parts of your code involve caching you may want to either throw out the first run's results in each version of the code base, since that's where the cache will be generated, or clear the cache between runs.
 
@@ -54,7 +54,7 @@ Go ahead and test your run scripts to make sure that you can get a consistent ba
 
 After all this set-up, you should be ready to experiment and see what the impact of changes in your code base are on the metrics that you want to shift. In my case, the code I was working on used a [streaming JSON parser class](https://github.com/squix78/jsonstreamingparser), and I noticed that one of the top function calls in the inital profiler report was the `consumeChar` method of the parser.
 
-<img src="/assets/img/blog/xhprof-results-page.jpg" alt="Image of XHProf profiler report with the method consumeChar highlighted in yellow">
+<img src="/assets/img/blog/xhprof-results-page.jpg" alt="Image of XHProf profiler report with the method consumeChar highlighted in yellow" class="blog-image-full-width">
 
 It turns out that the JSON files I was importing were pretty-printed, thus containing more whitespace than they needed to. Sine the `consumeChar` method gets called on each incoming character of the input stream, that added up to a lot of unnecessary method calls in the original code. By tweaking the JSON file export code to remove the pretty print flag, I cut down the number of times this method was called from 729,099 to 499,809, saving .2 seconds of run time right off the bat.
 

--- a/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
+++ b/_posts/2016-10-19-optimizing-jekyll-with-gulp.md
@@ -40,7 +40,7 @@ to be able to practice what we preach!
 
 Our ultimate motivator was our not-so-great Google PageSpeed score.
 
-![Initial Google PageSpeed Insights score for savaslabs.com. Several significant problems exist!]({{ site.url }}/assets/img/blog/pagespeed-insights-initial.jpg)
+![Initial Google PageSpeed Insights score for savaslabs.com. Several significant problems exist!]({{ site.url }}/assets/img/blog/pagespeed-insights-initial.jpg){:class="blog-image-full-width"}
 <span class="caption">Yikes!</span>
 
 Going off of these recommendations and adding a few things of our own, we ended
@@ -106,7 +106,7 @@ we created a `gulp serve` task using `gulp.watch()` to process assets as
 they're updated and copy them directly into the `_site` directory, then push the
 changes to the browser via BrowserSync.
 
-![Diagram of our basic gulp workflow]({{ site.url }}/assets/img/blog/gulp-workflow.svg)
+![Diagram of our basic gulp workflow]({{ site.url }}/assets/img/blog/gulp-workflow.svg){:class="blog-image-full-width"}
 
 ### Changes to Jekyll config
 
@@ -898,7 +898,7 @@ injected is fantastic!
 After implementing these changes, our mobile PageSpeed score shot up to 92/100,
 with our desktop score at 95/100!
 
-<img src="/assets/img/blog/pagespeed-insights-results.jpg" alt="95/100 Google PageSpeed Insights score!">
+<img src="/assets/img/blog/pagespeed-insights-results.jpg" alt="95/100 Google PageSpeed Insights score!" class="blog-image-full-width">
 
 ---
 
@@ -907,7 +907,7 @@ doing great in the user experience department.
 
 ---
 
-<img src="/assets/img/blog/pagespeed-insights-user-experience.jpg" alt="Passing Google PageSpeed Insights user experience items.">
+<img src="/assets/img/blog/pagespeed-insights-user-experience.jpg" alt="Passing Google PageSpeed Insights user experience items." class="blog-image-full-width">
 
 ---
 

--- a/_posts/2016-10-25-deploy-jekyll-with-travis.md
+++ b/_posts/2016-10-25-deploy-jekyll-with-travis.md
@@ -29,7 +29,7 @@ up Travis in their [docs](https://docs.travis-ci.com/).
 Previously, Travis would build the site and run our tests, then we would merge
 branches into `master`, triggering GitHub Pages to rebuild and deploy our site.
 
-![Diagram of original deployment workflow]({{ site.url }}/assets/img/blog/original-deployment-workflow.jpg)
+![Diagram of original deployment workflow]({{ site.url }}/assets/img/blog/original-deployment-workflow.jpg){:class="blog-image-full-width"}
 <span class="caption">Original deployment workflow</span>
 
 Now, we want to build our site before it gets to GitHub Pages to ensure our
@@ -43,7 +43,7 @@ builds the site.
 directory to the `master` branch, then pushes the `master` branch.
 4. This triggers GitHub Pages to deploy our pre-built site.
 
-![Diagram of new deployment workflow]({{ site.url }}/assets/img/blog/new-deployment-workflow.jpg)
+![Diagram of new deployment workflow]({{ site.url }}/assets/img/blog/new-deployment-workflow.jpg){:class="blog-image-full-width"}
 <span class="caption">New deployment workflow</span>
 
 ### Create a new default branch
@@ -67,7 +67,7 @@ a personal access token by visiting the
 new token. We used a bot account that has access to our repository to avoid
 needing to use one of our personal accounts.
 
-![Generating a personal access token in GitHub]({{ site.url }}/assets/img/blog/github-token.jpg)
+![Generating a personal access token in GitHub]({{ site.url }}/assets/img/blog/github-token.jpg){:class="blog-image-full-width"}
 
 We'll need to use the access token and the account's email address in our
 deployment script, so to keep those items out of version control we used

--- a/_posts/2017-02-27-on-web-typography-review.md
+++ b/_posts/2017-02-27-on-web-typography-review.md
@@ -34,7 +34,7 @@ process.
 
 ## Base knowledge
 
-![A diagram of typeface terminology]({{ site.url }}/assets/img/blog/on-web-typography-typeface-anatomy.jpg)
+![A diagram of typeface terminology]({{ site.url }}/assets/img/blog/on-web-typography-typeface-anatomy.jpg){:class="blog-image-full-width"}
 <span class="caption">A diagram of typeface anatomy<br>
 *From* [On Web Typography](https://abookapart.com/products/on-web-typography) *by Jason Santa Maria*</span>
 
@@ -57,7 +57,7 @@ offer (true bolds and italics, language sets and punctuation among others)
 
 ## Evaluating typefaces
 
-![Examples of alternatives to Helvetica based on Helvetica's physical characteristics]({{ site.url }}/assets/img/blog/on-web-typography-helvetica-alternatives.jpg)
+![Examples of alternatives to Helvetica based on Helvetica's physical characteristics]({{ site.url }}/assets/img/blog/on-web-typography-helvetica-alternatives.jpg){:class="blog-image-full-width"}
 <span class="caption">Finding alternatives to Helvetica by examining its physical characteristics<br>
 *From* [On Web Typography](https://abookapart.com/products/on-web-typography) *by Jason Santa Maria*</span>
 
@@ -76,7 +76,7 @@ All the previous sections culminate in the ultimate goal: how to design type for
 your site. Santa Maria introduces two separate contexts to consider: type for a
 moment (a menu link, a heading, etc.) and type to live with (long text).
 
-![Examples of type in different contexts]({{ site.url }}/assets/img/blog/on-web-typography-contexts.jpg)
+![Examples of type in different contexts]({{ site.url }}/assets/img/blog/on-web-typography-contexts.jpg){:class="blog-image-full-width"}
 <span class="caption">Some examples of the two contexts</span>
 
 These contexts demand different typeface choices based on what's important
@@ -113,7 +113,7 @@ bookmarking the source in an "Inspiration" folder. [Entire books have been
 written about this process](http://austinkleon.com/steal/), so don't be afraid
 to be inspired by others' work!
 
-![Screenshots of websites with nice type design]({{ site.url }}/assets/img/blog/on-web-typography-inspiration.jpg)
+![Screenshots of websites with nice type design]({{ site.url }}/assets/img/blog/on-web-typography-inspiration.jpg){:class="blog-image-full-width"}
 <span class="caption">Some samples from my Inspiration folder</span>
 
 After perusing my Inspiration folder, I follow these guidelines when designing


### PR DESCRIPTION
Fixes issues [#3423](https://pm.savaslabs.com/issues/3423) and [#4570](https://pm.savaslabs.com/issues/4570)

## Summary of changes

To improve readability in blog posts, I've made the following changes to text in the blog post body:

- Change font family to Roboto (from Roboto Condensed)
- Increase font size and line height
- Adds more and more left/right padding to text on larger screens (above 1120px) so paragraphs aren't overly wide
- Adds corresponding increases in width and negative margins to full size and floated blog images, so these images always appear larger than text on large screens. This is mostly important for full width blog images, which should span the width of the article container (issue #4570).
- Update some images on blog posts to add the `blog-image-full-width` class, which makes the image slightly wider than the body text
- Updates the README with relevant info

## Notes

I removed caption styles for `.blog-image-left` and `.blog-image-right` because we don't really have the capability to add captions to these kinds of images right now, and we're not using captions with any floated images at the moment.

## To test

- Pull this and run `gulp clean` and `gulp serve`
- Check out some blog posts to ensure the text and images look right, especially on very large screens
- View some posts on small screens (mobile size) to ensure the larger text isn't doing anything undesirable like overflowing the container

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
#