### PR TITLE
Issue #518: Add pre-commit hook test for Drupal Planet items

### DIFF
--- a/_posts/2017-10-27-drupal-8-turns-2.md
+++ b/_posts/2017-10-27-drupal-8-turns-2.md
@@ -7,6 +7,9 @@ tags: drupal drupal8 drupal-planet
 summary: Drupal 8 has been around for almost two years. We take a look at where it's been and where it's going.
 featured_image: "/blog/drupal-7-outweighs-8.jpg"
 featured_image_alt: "Drupal 7 outweighs Drupal 8 in 2016"
+drupal_planet_summary: |
+  Drupal 8 has been around for almost two years. In the first of a two-part series, we take a look at how successful Drupal 8 has been. In the second, we'll investigate its future value and the cost of developing on older platforms.
+
 ---
 
 Drupal 8's official release was [nearly two years ago](https://www.drupal.org/blog/drupal-800-released), and many ask how is it doing? Has it lived up to its ambition to revolutionize Drupal websites?

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -56,10 +56,37 @@ else
 ${YELLOW}You can ignore these suggestions and proceed with your
 commit by running git commit with the --no-verify tag.
 Don't worry, proselint is a bit picky!\n\n${NC}"
-    echo "$SUGGESTIONS\n"
+    echo "$SUGGESTIONS"
     PASS=false
   fi
 fi
+
+# Check for Drupal Planet tag and summary if relevant.
+DASHES="---"
+for FILE in $(git diff-index --cached HEAD --name-only | grep -E '_posts')
+do
+  FRONT_MATTER=$(sed -n '/^---$/,/^---$/p' $FILE)
+  FRONT_MATTER=${FRONT_MATTER#${DASHES}}
+  FRONT_MATTER=${FRONT_MATTER%${DASHES}}
+
+  # If it's a Drupal post...
+  if [[ $FRONT_MATTER == *" drupal"* ]]; then
+    # Check for the Drupal Planet tag...
+    if [[ $FRONT_MATTER == *" drupal-planet"* ]]; then
+      # If that's found, check for a Drupal Planet summary.
+      if [[ $FRONT_MATTER != *"drupal_planet_summary:"* ]]; then
+        printf "${RED}\nYour post $FILE is missing a Drupal Planet summary.
+${YELLOW}Please include a Drupal Planet summary in your post's front matter.\n\n${NC}"
+        PASS=false
+      fi
+    else
+      printf "${YELLOW}\nYou've tagged $FILE as a Drupal post.
+If appropriate, you should consider including the Drupal Planet tag and
+summary as well. To ignore this and proceed, use git commit --no-verify.\n\n${NC}"
+      PASS=false
+    fi
+  fi
+done
 
 # If there were no failures, proceed with commit.
 if $PASS; then


### PR DESCRIPTION
Fixes issue [#518](https://pm.savaslabs.com/issues/518)

## Summary of changes

1. Adds a test to the pre-commit hook that checks the following:
  - If the `drupal` tag is found, it suggests adding the `drupal-planet` tag and summary
  - If the `drupal-planet` tag is found but no summary, it tells the user to add the summary

## To test

- Pull this code
- Edit your latest blog post and add it to your git stage
- Run `git commit`. You should get an error that you need to add a Drupal Planet summary
- Try removing the `drupal-planet` tag from the post and committing. You should get a suggestion to add the `drupal-planet` tag and summary
- Add a drupal planet summary and confirm you get no warnings/errors when you commit
- Edit another markdown file (e.g. a service) and add it to the git stage. Try committing - you should get no warnings about drupal planet related to that file.

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment
