### PR TITLE
Use comment server variable for post URI

### DIFF
--- a/_comments-app/utils/api.js
+++ b/_comments-app/utils/api.js
@@ -2,12 +2,15 @@ import axios from 'axios';
 
 // Jekyll variable; see config files.
 const commentServer = '{{ site.comment_server_url }}';
-const postSlug = window.location.pathname;
 
-// Remove leading forward slash.
+// Create URI for fetching comments.
+const postSlug = window.location.pathname;
 const truncatedSlug = postSlug.substring(1, postSlug.length);
 const encodedSlug = encodeURIComponent(truncatedSlug);
 const requestUri = commentServer + '/api/comments/post?slug=' + encodedSlug;
+
+// Create URI for posting comment.
+const postUri = commentServer + '/api/comments/new';
 
 module.exports = {
   getComments: function () {
@@ -24,7 +27,7 @@ module.exports = {
     'use strict';
     return axios({
       method: 'post',
-      url: 'http://local.comments.savaslabs.com/api/comments/new',
+      url: postUri,
       data: commentData
     })
       .then(function (response) {


### PR DESCRIPTION
## Summary of changes

- Uses the Jekyll comment server variable for the post URI (this was previously hardcoded with the local URI)

## Notes

I tested this by building for local dev and for production and looking at the get/post URIs used in our API calls.

## To test

- Do the same thing, or not ¯\\\_(ツ)_/¯

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
