### PR TITLE
Issue #4974: decode comment HTML

### DIFF
--- a/_comments-app/components/Comments.js
+++ b/_comments-app/components/Comments.js
@@ -36,7 +36,7 @@ class Comment extends Component {
     return dom.body.textContent;
   }
   render () {
-    const commentText = this.decodeHtml(this.props.comment);
+    const commentText = Comment.decodeHtml(this.props.comment);
     return (
       <li className={this.props.class}>
         {this.props.savasian === '1' && <img src='/assets/img/logo.svg' className='comment__logo' alt='Savas Labs logo' />}

--- a/_comments-app/components/Comments.js
+++ b/_comments-app/components/Comments.js
@@ -22,15 +22,30 @@ CommentFormLink.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
-function Comment (props) {
-  return (
-    <li className={props.class}>
-      {props.savasian === '1' && <img src='/assets/img/logo.svg' className='comment__logo' alt='Savas Labs logo' />}
-      <p className="comment__name"><span className="c-magenta">{props.name}</span> says:</p>
-      <p className="comment__date">{props.date}</p>
-      <p className="comment__text">{props.comment}</p>
-    </li>
-  );
+class Comment extends Component {
+  /**
+   * Convert encoded HTML before displaying a comment.
+   *
+   * @param commentText
+   */
+  static decodeHtml(commentText) {
+    const parser = new DOMParser;
+    const dom = parser.parseFromString(
+      '<!doctype html><body>' + commentText,
+      'text/html');
+    return dom.body.textContent;
+  }
+  render () {
+    const commentText = this.decodeHtml(this.props.comment);
+    return (
+      <li className={this.props.class}>
+        {this.props.savasian === '1' && <img src='/assets/img/logo.svg' className='comment__logo' alt='Savas Labs logo' />}
+        <p className="comment__name"><span className="c-magenta">{this.props.name}</span> says:</p>
+        <p className="comment__date">{this.props.date}</p>
+        <p className="comment__text">{commentText}</p>
+      </li>
+    );
+  }
 }
 
 Comment.propTypes = {


### PR DESCRIPTION
Fixes issue [#4974](https://pm.savaslabs.com/issues/4974)

## Summary of changes

- Decodes comment HTML before displaying using [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser)

## Notes

This works, but you'll have to let me know what you think security-wise. Most of the solutions I found were some form of this, placing the encoded HTML string into an HTML element then extracting the text.

This is also a temporary measure since we'll be implementing a text editor soon.

## To test

- Get local squabble instance running
- `gulp clean && gulp serve`
- Add a comment to a post with various characters like apostrophes and quotation marks
- Try to break it

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
