### PR TITLE
Issue #4961: JS coding standards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,39 +1,40 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "amd": true,
-        "es6": true
+  "env": {
+    "browser": true,
+    "amd": true,
+    "es6": true,
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
     },
-    "extends": ["eslint:recommended", "plugin:react/recommended"],
-    "parserOptions": {
-        "ecmaFeatures": {
-            "experimentalObjectRestSpread": true,
-            "jsx": true
-        },
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react"
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react"
+  ],
+  "globals": {
+    "module": false,
+    "require": false
+  },
+  "rules": {
+    "indent": [
+      "error",
+      2
     ],
-    "globals": {
-        "module": false,
-    },
-    "rules": {
-        "indent": [
-            "error",
-            2
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
-    }
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  }
 };

--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -5,7 +5,7 @@ $(document).ready(
     'use strict';
     const $menuToggle = $('#js-mobile-menu').unbind();
     const $menu = $('#js-navigation-menu');
-    $menu.removeClass("show");
+    $menu.removeClass('show');
 
     $menuToggle.on(
       'click', function (e) {
@@ -24,9 +24,9 @@ $(document).ready(
 $(document).ready(
   function () {
     'use strict';
-    $('a[href*="#"]:not([href="#"])').click(function () {
-      if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && location.hostname == this.hostname) {
-        var target = $(this.hash);
+    $('a[href*="#"]').not('[href="#"]').click(function () {
+      if (location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '') && location.hostname === this.hostname) {
+        let target = $(this.hash);
         target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
         if (target.length) {
           $('html, body').animate({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,28 +14,29 @@
  */
 
 // Define variables.
-var accessibility  = require('gulp-accessibility');
-var appendPrepend  = require('gulp-append-prepend');
-var autoprefixer   = require('autoprefixer');
-var browserSync    = require('browser-sync').create();
-var cache          = require('gulp-cache');
-var cleancss       = require('gulp-clean-css');
-var concat         = require('gulp-concat');
-var del            = require('del');
-var gulp           = require('gulp');
-var gutil          = require('gulp-util');
-var imagemin       = require('gulp-imagemin');
-var jpegRecompress = require('imagemin-jpeg-recompress');
-var notify         = require('gulp-notify');
-var postcss        = require('gulp-postcss');
-var rename         = require('gulp-rename');
-var run            = require('gulp-run');
-var runSequence    = require('run-sequence');
-var sass           = require('gulp-ruby-sass');
-var uglify         = require('gulp-uglify');
+const accessibility = require('gulp-accessibility');
+const appendPrepend = require('gulp-append-prepend');
+const autoprefixer = require('autoprefixer');
+const babel = require('gulp-babel');
+const browserSync = require('browser-sync').create();
+const cache = require('gulp-cache');
+const cleancss = require('gulp-clean-css');
+const concat = require('gulp-concat');
+const del = require('del');
+const gulp = require('gulp');
+const gutil = require('gulp-util');
+const imagemin = require('gulp-imagemin');
+const jpegRecompress = require('imagemin-jpeg-recompress');
+const notify = require('gulp-notify');
+const postcss = require('gulp-postcss');
+const rename = require('gulp-rename');
+const run = require('gulp-run');
+const runSequence = require('run-sequence');
+const sass = require('gulp-ruby-sass');
+const uglify = require('gulp-uglify');
 
 // Include paths.
-var paths          = require('./_assets/gulp_config/paths');
+const paths = require('./_assets/gulp_config/paths');
 
 // -----------------------------------------------------------------------------
 //   1: Styles
@@ -47,18 +48,18 @@ var paths          = require('./_assets/gulp_config/paths');
  * Uses Sass compiler to process styles, adds vendor prefixes, minifies, then
  * outputs file to the appropriate location.
  */
-gulp.task('build:styles:main', function() {
-    return sass(paths.sassFiles + '/main.scss', {
-        style: 'compressed',
-        trace: true,
-        loadPath: [paths.sassFiles]
-    }).pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
-        .pipe(cleancss())
-        .pipe(gulp.dest(paths.jekyllCssFiles))
-        .pipe(gulp.dest(paths.siteCssFiles))
-        .pipe(gulp.dest(paths.siteStyleGuide))
-        .pipe(browserSync.stream())
-        .on('error', gutil.log);
+gulp.task('build:styles:main', function () {
+  return sass(paths.sassFiles + '/main.scss', {
+    style: 'compressed',
+    trace: true,
+    loadPath: [paths.sassFiles]
+  }).pipe(postcss([autoprefixer({browsers: ['last 2 versions']})]))
+    .pipe(cleancss())
+    .pipe(gulp.dest(paths.jekyllCssFiles))
+    .pipe(gulp.dest(paths.siteCssFiles))
+    .pipe(gulp.dest(paths.siteStyleGuide))
+    .pipe(browserSync.stream())
+    .on('error', gutil.log);
 });
 
 /**
@@ -66,15 +67,15 @@ gulp.task('build:styles:main', function() {
  *
  * Processes critical CSS, to be included in head.html.
  */
-gulp.task('build:styles:critical', function() {
-    return sass(paths.sassFiles + '/critical*.scss', {
-        style: 'compressed',
-        trace: true,
-        loadPath: [paths.sassFiles]
-    }).pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
-        .pipe(cleancss())
-        .pipe(gulp.dest('_includes/css'))
-        .on('error', gutil.log);
+gulp.task('build:styles:critical', function () {
+  return sass(paths.sassFiles + '/critical*.scss', {
+    style: 'compressed',
+    trace: true,
+    loadPath: [paths.sassFiles]
+  }).pipe(postcss([autoprefixer({browsers: ['last 2 versions']})]))
+    .pipe(cleancss())
+    .pipe(gulp.dest('_includes/css'))
+    .on('error', gutil.log);
 });
 
 /**
@@ -83,13 +84,13 @@ gulp.task('build:styles:critical', function() {
  * Copies any other CSS files to the assets directory, to be used by pages/posts
  * that specify custom CSS files.
  */
-gulp.task('build:styles:css', function() {
-    return gulp.src([paths.sassFiles + '/*.css'])
-      .pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
-      .pipe(cleancss())
-      .pipe(gulp.dest(paths.jekyllCssFiles))
-      .pipe(gulp.dest(paths.siteCssFiles))
-      .on('error', gutil.log);
+gulp.task('build:styles:css', function () {
+  return gulp.src([paths.sassFiles + '/*.css'])
+    .pipe(postcss([autoprefixer({browsers: ['last 2 versions']})]))
+    .pipe(cleancss())
+    .pipe(gulp.dest(paths.jekyllCssFiles))
+    .pipe(gulp.dest(paths.siteCssFiles))
+    .on('error', gutil.log);
 });
 
 /**
@@ -98,9 +99,9 @@ gulp.task('build:styles:css', function() {
  * Builds all site styles.
  */
 gulp.task('build:styles', [
-    'build:styles:main',
-    'build:styles:critical',
-    'build:styles:css'
+  'build:styles:main',
+  'build:styles:critical',
+  'build:styles:css'
 ]);
 
 /**
@@ -108,9 +109,9 @@ gulp.task('build:styles', [
  *
  * Deletes all processed site styles.
  */
-gulp.task('clean:styles', function(callback) {
-    del([paths.jekyllCssFiles, paths.siteCssFiles, '_includes/critical.css']);
-    callback();
+gulp.task('clean:styles', function (callback) {
+  del([paths.jekyllCssFiles, paths.siteCssFiles, '_includes/critical.css']);
+  callback();
 });
 
 /**
@@ -118,18 +119,18 @@ gulp.task('clean:styles', function(callback) {
  *
  * Generates CSS for the style guide.
  */
-gulp.task('build:styles:styleguide', function() {
-    return sass(paths.sassFiles + '/styleguide.scss', {
-        style: 'compressed',
-        trace: true,
-        loadPath: [paths.sassFiles]
-    }).pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
-      .pipe(cleancss())
-      .pipe(gulp.dest(paths.styleGuideAssets))
-      .pipe(gulp.dest('styleguide'))
-      .pipe(gulp.dest(paths.siteStyleGuide))
-      .pipe(browserSync.stream())
-      .on('error', gutil.log);
+gulp.task('build:styles:styleguide', function () {
+  return sass(paths.sassFiles + '/styleguide.scss', {
+    style: 'compressed',
+    trace: true,
+    loadPath: [paths.sassFiles]
+  }).pipe(postcss([autoprefixer({browsers: ['last 2 versions']})]))
+    .pipe(cleancss())
+    .pipe(gulp.dest(paths.styleGuideAssets))
+    .pipe(gulp.dest('styleguide'))
+    .pipe(gulp.dest(paths.siteStyleGuide))
+    .pipe(browserSync.stream())
+    .on('error', gutil.log);
 });
 
 // -----------------------------------------------------------------------------
@@ -142,17 +143,20 @@ gulp.task('build:styles:styleguide', function() {
  * Concatenates and uglifies global JS files and outputs result to the
  * appropriate location.
  */
-gulp.task('build:scripts:global', function() {
-    return gulp.src([
-        paths.jsFiles + '/global/lib' + paths.jsPattern,
-        paths.jsFiles + '/global/*.js'
-    ])
-        .pipe(concat('main.js'))
-        .pipe(uglify())
+gulp.task('build:scripts:global', function () {
+  return gulp.src([
+    paths.jsFiles + '/global/lib' + paths.jsPattern,
+    paths.jsFiles + '/global/*.js'
+  ])
+    .pipe(concat('main.js'))
+    .pipe(babel({
+      presets: ['es2015']
+    }))
+    .pipe(uglify())
 
-        // Only place in `assets` because Jekyll needs to process the file.
-        .pipe(gulp.dest(paths.jekyllJsFiles))
-        .on('error', gutil.log);
+    // Only place in `assets` because Jekyll needs to process the file.
+    .pipe(gulp.dest(paths.jekyllJsFiles))
+    .on('error', gutil.log);
 });
 
 /**
@@ -161,9 +165,9 @@ gulp.task('build:scripts:global', function() {
  * Special task for running webpack to compile React code for comments app for
  * production.
  */
-gulp.task('build:scripts:webpack', function() {
-    return gulp.src('')
-      .pipe(run('npm run build-comments'));
+gulp.task('build:scripts:webpack', function () {
+  return gulp.src('')
+    .pipe(run('npm run build-comments'));
 });
 
 /**
@@ -172,9 +176,9 @@ gulp.task('build:scripts:webpack', function() {
  * Special task for running webpack to compile React code for comments app for
  * development.
  */
-gulp.task('build:scripts:webpack:dev', function() {
-    return gulp.src('')
-      .pipe(run('npm run build-comments-dev'));
+gulp.task('build:scripts:webpack:dev', function () {
+  return gulp.src('')
+    .pipe(run('npm run build-comments-dev'));
 });
 
 /**
@@ -182,16 +186,16 @@ gulp.task('build:scripts:webpack:dev', function() {
  *
  * Copies comments app to the assets directory.
  */
-gulp.task('build:scripts:comments', function() {
-    return gulp.src([
-        paths.jsFiles + '/comments.js'
-    ])
-        // We need to add front matter so Jekyll will process variables.
-      .pipe(appendPrepend.prependFile('./_assets/gulp_config/front-matter.txt'))
+gulp.task('build:scripts:comments', function () {
+  return gulp.src([
+    paths.jsFiles + '/comments.js'
+  ])
+    // We need to add front matter so Jekyll will process variables.
+    .pipe(appendPrepend.prependFile('./_assets/gulp_config/front-matter.txt'))
 
-      // Only place in `assets` because Jekyll needs to process the file.
-      .pipe(gulp.dest(paths.jekyllJsFiles))
-      .on('error', gutil.log);
+    // Only place in `assets` because Jekyll needs to process the file.
+    .pipe(gulp.dest(paths.jekyllJsFiles))
+    .on('error', gutil.log);
 });
 
 /**
@@ -200,16 +204,16 @@ gulp.task('build:scripts:comments', function() {
  * Concatenates and uglifies leaflet JS files and outputs result to the
  * appropriate location.
  */
-gulp.task('build:scripts:leaflet', function() {
-    return gulp.src([
-        paths.jsFiles + '/leaflet/leaflet.js',
-        paths.jsFiles + '/leaflet/leaflet-providers.js'
-    ])
-        .pipe(concat('leaflet.js'))
-        .pipe(uglify())
-        .pipe(gulp.dest(paths.jekyllJsFiles))
-        .pipe(gulp.dest(paths.siteJsFiles))
-        .on('error', gutil.log);
+gulp.task('build:scripts:leaflet', function () {
+  return gulp.src([
+    paths.jsFiles + '/leaflet/leaflet.js',
+    paths.jsFiles + '/leaflet/leaflet-providers.js'
+  ])
+    .pipe(concat('leaflet.js'))
+    .pipe(uglify())
+    .pipe(gulp.dest(paths.jekyllJsFiles))
+    .pipe(gulp.dest(paths.siteJsFiles))
+    .on('error', gutil.log);
 });
 
 /**
@@ -217,10 +221,10 @@ gulp.task('build:scripts:leaflet', function() {
  *
  * Builds all scripts.
  */
-gulp.task('build:scripts', function(callback) {
-    runSequence('build:scripts:webpack',
-      ['build:scripts:global', 'build:scripts:comments', 'build:scripts:leaflet'],
-      callback);
+gulp.task('build:scripts', function (callback) {
+  runSequence('build:scripts:webpack',
+    ['build:scripts:global', 'build:scripts:comments', 'build:scripts:leaflet'],
+    callback);
 });
 
 /**
@@ -228,10 +232,10 @@ gulp.task('build:scripts', function(callback) {
  *
  * Builds all scripts, running webpack for dev environment.
  */
-gulp.task('build:scripts:dev', function(callback) {
-    runSequence('build:scripts:webpack:dev',
-      ['build:scripts:global', 'build:scripts:comments', 'build:scripts:leaflet'],
-      callback);
+gulp.task('build:scripts:dev', function (callback) {
+  runSequence('build:scripts:webpack:dev',
+    ['build:scripts:global', 'build:scripts:comments', 'build:scripts:leaflet'],
+    callback);
 });
 
 /**
@@ -239,9 +243,9 @@ gulp.task('build:scripts:dev', function(callback) {
  *
  * Deletes all processed scripts.
  */
-gulp.task('clean:scripts', function(callback) {
-    del([paths.jekyllJsFiles, paths.siteJsFiles]);
-    callback();
+gulp.task('clean:scripts', function (callback) {
+  del([paths.jekyllJsFiles, paths.siteJsFiles]);
+  callback();
 });
 
 // -----------------------------------------------------------------------------
@@ -256,17 +260,17 @@ gulp.task('clean:scripts', function(callback) {
  * We're including imagemin options because we're overriding the default JPEG
  * optimization plugin.
  */
-gulp.task('build:images', function() {
-    return gulp.src(paths.imageFilesGlob)
-        .pipe(cache(imagemin([
-            imagemin.gifsicle(),
-            jpegRecompress(),
-            imagemin.optipng(),
-            imagemin.svgo()
-        ])))
-        .pipe(gulp.dest(paths.jekyllImageFiles))
-        .pipe(gulp.dest(paths.siteImageFiles))
-        .pipe(browserSync.stream());
+gulp.task('build:images', function () {
+  return gulp.src(paths.imageFilesGlob)
+    .pipe(cache(imagemin([
+      imagemin.gifsicle(),
+      jpegRecompress(),
+      imagemin.optipng(),
+      imagemin.svgo()
+    ])))
+    .pipe(gulp.dest(paths.jekyllImageFiles))
+    .pipe(gulp.dest(paths.siteImageFiles))
+    .pipe(browserSync.stream());
 });
 
 /**
@@ -274,9 +278,9 @@ gulp.task('build:images', function() {
  *
  * Deletes all processed images.
  */
-gulp.task('clean:images', function(callback) {
-    del([paths.jekyllImageFiles, paths.siteImageFiles]);
-    callback();
+gulp.task('clean:images', function (callback) {
+  del([paths.jekyllImageFiles, paths.siteImageFiles]);
+  callback();
 });
 
 // -----------------------------------------------------------------------------
@@ -295,13 +299,15 @@ gulp.task('build:fonts', ['fontawesome']);
  *
  * Places Font Awesome fonts in the proper location.
  */
-gulp.task('fontawesome', function() {
-    return gulp.src(paths.fontFiles + '/font-awesome/**.*')
-        .pipe(rename(function(path) {path.dirname = '';}))
-        .pipe(gulp.dest(paths.jekyllFontFiles))
-        .pipe(gulp.dest(paths.siteFontFiles))
-        .pipe(browserSync.stream())
-        .on('error', gutil.log);
+gulp.task('fontawesome', function () {
+  return gulp.src(paths.fontFiles + '/font-awesome/**.*')
+    .pipe(rename(function (path) {
+      path.dirname = '';
+    }))
+    .pipe(gulp.dest(paths.jekyllFontFiles))
+    .pipe(gulp.dest(paths.siteFontFiles))
+    .pipe(browserSync.stream())
+    .on('error', gutil.log);
 });
 
 /**
@@ -309,9 +315,9 @@ gulp.task('fontawesome', function() {
  *
  * Deletes all processed fonts.
  */
-gulp.task('clean:fonts', function(callback) {
-    del([paths.jekyllFontFiles, paths.siteFontFiles]);
-    callback();
+gulp.task('clean:fonts', function (callback) {
+  del([paths.jekyllFontFiles, paths.siteFontFiles]);
+  callback();
 });
 
 // -----------------------------------------------------------------------------
@@ -323,12 +329,12 @@ gulp.task('clean:fonts', function(callback) {
  *
  * Runs the jekyll build command.
  */
-gulp.task('build:jekyll', function() {
-    var shellCommand = 'bundle exec jekyll build --config _config.yml';
+gulp.task('build:jekyll', function () {
+  const shellCommand = 'bundle exec jekyll build --config _config.yml';
 
-    return gulp.src('')
-        .pipe(run(shellCommand))
-        .on('error', gutil.log);
+  return gulp.src('')
+    .pipe(run(shellCommand))
+    .on('error', gutil.log);
 });
 
 /**
@@ -336,12 +342,12 @@ gulp.task('build:jekyll', function() {
  *
  * Runs the jekyll build command using the test config file.
  */
-gulp.task('build:jekyll:test', function() {
-    var shellCommand = 'bundle exec jekyll build --future --config _config.yml,_config.test.yml';
+gulp.task('build:jekyll:test', function () {
+  const shellCommand = 'bundle exec jekyll build --future --config _config.yml,_config.test.yml';
 
-    return gulp.src('')
-        .pipe(run(shellCommand))
-        .on('error', gutil.log);
+  return gulp.src('')
+    .pipe(run(shellCommand))
+    .on('error', gutil.log);
 });
 
 /**
@@ -349,12 +355,12 @@ gulp.task('build:jekyll:test', function() {
  *
  * Runs the jekyll build command using the test and local config files.
  */
-gulp.task('build:jekyll:local', function() {
-    var shellCommand = 'bundle exec jekyll build --future --config _config.yml,_config.test.yml,_config.dev.yml';
+gulp.task('build:jekyll:local', function () {
+  const shellCommand = 'bundle exec jekyll build --future --config _config.yml,_config.test.yml,_config.dev.yml';
 
-    return gulp.src('')
-        .pipe(run(shellCommand))
-        .on('error', gutil.log);
+  return gulp.src('')
+    .pipe(run(shellCommand))
+    .on('error', gutil.log);
 });
 
 /**
@@ -362,9 +368,9 @@ gulp.task('build:jekyll:local', function() {
  *
  * Deletes the entire _site directory.
  */
-gulp.task('clean:jekyll', function(callback) {
-    del(['_site']);
-    callback();
+gulp.task('clean:jekyll', function (callback) {
+  del(['_site']);
+  callback();
 });
 
 /**
@@ -373,23 +379,23 @@ gulp.task('clean:jekyll', function(callback) {
  * Runs all the clean commands.
  */
 gulp.task('clean', ['clean:jekyll',
-    'clean:fonts',
-    'clean:images',
-    'clean:scripts',
-    'clean:styles',
-    'clean:styleguide']);
+  'clean:fonts',
+  'clean:images',
+  'clean:scripts',
+  'clean:styles',
+  'clean:styleguide']);
 
 /**
  * Task: build
  *
  * Build the site anew.
  */
-gulp.task('build', function(callback) {
-    runSequence('clean',
-        ['build:scripts', 'build:images', 'build:styles', 'build:fonts'],
-        'styleguide',
-        'build:jekyll',
-        callback);
+gulp.task('build', function (callback) {
+  runSequence('clean',
+    ['build:scripts', 'build:images', 'build:styles', 'build:fonts'],
+    'styleguide',
+    'build:jekyll',
+    callback);
 });
 
 /**
@@ -397,12 +403,12 @@ gulp.task('build', function(callback) {
  *
  * Builds the site anew using test config.
  */
-gulp.task('build:test', function(callback) {
-    runSequence('clean',
-        ['build:scripts', 'build:images', 'build:styles', 'build:fonts'],
-        'styleguide',
-        'build:jekyll:test',
-        callback);
+gulp.task('build:test', function (callback) {
+  runSequence('clean',
+    ['build:scripts', 'build:images', 'build:styles', 'build:fonts'],
+    'styleguide',
+    'build:jekyll:test',
+    callback);
 });
 
 /**
@@ -410,12 +416,12 @@ gulp.task('build:test', function(callback) {
  *
  * Builds the site anew using test and local config.
  */
-gulp.task('build:local', function(callback) {
-    runSequence('clean',
-        ['build:scripts:dev', 'build:images', 'build:styles', 'build:fonts'],
-        'styleguide',
-        'build:jekyll:local',
-      callback);
+gulp.task('build:local', function (callback) {
+  runSequence('clean',
+    ['build:scripts:dev', 'build:images', 'build:styles', 'build:fonts'],
+    'styleguide',
+    'build:jekyll:local',
+    callback);
 });
 
 /**
@@ -430,9 +436,9 @@ gulp.task('default', ['build']);
  *
  * Special task for building the site then reloading via BrowserSync.
  */
-gulp.task('build:jekyll:watch', ['build:jekyll:local'], function(callback) {
-    browserSync.reload();
-    callback();
+gulp.task('build:jekyll:watch', ['build:jekyll:local'], function (callback) {
+  browserSync.reload();
+  callback();
 });
 
 /**
@@ -440,10 +446,10 @@ gulp.task('build:jekyll:watch', ['build:jekyll:local'], function(callback) {
  *
  * Special task for building scripts then reloading via BrowserSync.
  */
-gulp.task('build:scripts:watch', ['build:scripts:dev'], function(callback) {
-    runSequence('build:jekyll:local');
-    browserSync.reload();
-    callback();
+gulp.task('build:scripts:watch', ['build:scripts:dev'], function (callback) {
+  runSequence('build:jekyll:local');
+  browserSync.reload();
+  callback();
 });
 
 /**
@@ -454,73 +460,73 @@ gulp.task('build:scripts:watch', ['build:scripts:dev'], function(callback) {
  * Note: passing anything besides hard-coded literal paths with globs doesn't
  * seem to work with gulp.watch().
  */
-gulp.task('serve', ['build:local'], function() {
+gulp.task('serve', ['build:local'], function () {
 
-    browserSync.init({
-        server: paths.siteDir,
-        ghostMode: false, // Toggle to mirror clicks, reloads etc. (performance)
-        logFileChanges: true,
-        logLevel: 'debug',
-        open: true        // Toggle to automatically open page when starting.
-    });
+  browserSync.init({
+    server: paths.siteDir,
+    ghostMode: false, // Toggle to mirror clicks, reloads etc. (performance)
+    logFileChanges: true,
+    logLevel: 'debug',
+    open: true // Toggle to automatically open page when starting.
+  });
 
-    // Watch site settings.
-    gulp.watch(['_config*.yml'], ['build:jekyll:watch']);
+  // Watch site settings.
+  gulp.watch(['_config*.yml'], ['build:jekyll:watch']);
 
-    // Watch .scss files; changes are piped to browserSync.
-    // Ignore style guide SCSS.
-    // Rebuild the style guide to catch updates to component markup.
-    gulp.watch(
-      ['_assets/styles/**/*.scss', '!_assets/styles/scss/07-styleguide/**/*', '!_assets/styles/styleguide.scss'],
-      ['build:styles', 'build:styleguide']
-    );
+  // Watch .scss files; changes are piped to browserSync.
+  // Ignore style guide SCSS.
+  // Rebuild the style guide to catch updates to component markup.
+  gulp.watch(
+    ['_assets/styles/**/*.scss', '!_assets/styles/scss/07-styleguide/**/*', '!_assets/styles/styleguide.scss'],
+    ['build:styles', 'build:styleguide']
+  );
 
-    // Watch .js files.
-    gulp.watch(
-      ['_assets/js/**/*.js', '_comments-app/app/**/*'],
-      ['build:scripts:watch']
-    );
+  // Watch .js files.
+  gulp.watch(
+    ['_assets/js/**/*.js', '_comments-app/app/**/*'],
+    ['build:scripts:watch']
+  );
 
-    // Watch comment app files.
-    gulp.watch('_comments-app/**/*', ['build:scripts:watch']);
+  // Watch comment app files.
+  gulp.watch('_comments-app/**/*', ['build:scripts:watch']);
 
-    // Watch image files; changes are piped to browserSync.
-    gulp.watch('_assets/img/**/*', ['build:images']);
+  // Watch image files; changes are piped to browserSync.
+  gulp.watch('_assets/img/**/*', ['build:images']);
 
-    // Watch posts.
-    gulp.watch('_posts/**/*.+(md|markdown|MD)', ['build:jekyll:watch']);
+  // Watch posts.
+  gulp.watch('_posts/**/*.+(md|markdown|MD)', ['build:jekyll:watch']);
 
-    // Watch drafts if --drafts flag was passed.
-    if (module.exports.drafts) {
-        gulp.watch('_drafts/*.+(md|markdown|MD)', ['build:jekyll:watch']);
-    }
+  // Watch drafts if --drafts flag was passed.
+  if (module.exports.drafts) {
+    gulp.watch('_drafts/*.+(md|markdown|MD)', ['build:jekyll:watch']);
+  }
 
-    // Watch HTML and markdown files.
-    gulp.watch(
-      ['**/*.+(html|md|markdown|MD)', '!_site/**/*.*', '!_styleguide_assets/**/*.*', '!_assets/styles/*.md'],
-      ['build:jekyll:watch']
-    );
+  // Watch HTML and markdown files.
+  gulp.watch(
+    ['**/*.+(html|md|markdown|MD)', '!_site/**/*.*', '!_styleguide_assets/**/*.*', '!_assets/styles/*.md'],
+    ['build:jekyll:watch']
+  );
 
-    // Watch RSS feed XML files.
-    gulp.watch('**.xml', ['build:jekyll:watch']);
+  // Watch RSS feed XML files.
+  gulp.watch('**.xml', ['build:jekyll:watch']);
 
-    // Watch data files.
-    gulp.watch('_data/**.*+(yml|yaml|csv|json)', ['build:jekyll:watch']);
+  // Watch data files.
+  gulp.watch('_data/**.*+(yml|yaml|csv|json)', ['build:jekyll:watch']);
 
-    // Watch favicon.png.
-    gulp.watch('favicon.png', ['build:jekyll:watch']);
+  // Watch favicon.png.
+  gulp.watch('favicon.png', ['build:jekyll:watch']);
 
-    // Watch style guide SCSS.
-    gulp.watch(
-      ['_assets/styles/styleguide.scss', '_assets/styles/scss/07-styleguide/**/*.scss'],
-      ['build:styles:styleguide']
-    );
+  // Watch style guide SCSS.
+  gulp.watch(
+    ['_assets/styles/styleguide.scss', '_assets/styles/scss/07-styleguide/**/*.scss'],
+    ['build:styles:styleguide']
+  );
 
-    // Watch style guide HTML.
-    gulp.watch(
-      ['_styleguide_assets/*.html', '_assets/styles/*.md'],
-      ['build:styleguide', 'build:jekyll:watch']
-    );
+  // Watch style guide HTML.
+  gulp.watch(
+    ['_styleguide_assets/*.html', '_assets/styles/*.md'],
+    ['build:styleguide', 'build:jekyll:watch']
+  );
 });
 
 // -----------------------------------------------------------------------------
@@ -532,11 +538,11 @@ gulp.task('serve', ['build:local'], function() {
  *
  * Creates the style guide within the _site directory.
  */
-gulp.task('styleguide', function(callback) {
-    runSequence('clean:styleguide',
-      'build:styles:styleguide',
-      'build:styleguide',
-      callback);
+gulp.task('styleguide', function (callback) {
+  runSequence('clean:styleguide',
+    'build:styles:styleguide',
+    'build:styleguide',
+    callback);
 });
 
 /**
@@ -544,12 +550,12 @@ gulp.task('styleguide', function(callback) {
  *
  * Builds the style guide via the hologram gem.
  */
-gulp.task('build:styleguide', function(callback) {
-    var shellCommand = 'hologram -c hologram_config.yml';
+gulp.task('build:styleguide', function () {
+  const shellCommand = 'hologram -c hologram_config.yml';
 
-    return gulp.src('')
-      .pipe(run(shellCommand))
-      .on('error', gutil.log);
+  return gulp.src('')
+    .pipe(run(shellCommand))
+    .on('error', gutil.log);
 });
 
 /**
@@ -557,9 +563,9 @@ gulp.task('build:styleguide', function(callback) {
  *
  * Deletes the entire _site/styleguide directory.
  */
-gulp.task('clean:styleguide', function(callback) {
-    del(['styleguide', '_site/styleguide']);
-    callback();
+gulp.task('clean:styleguide', function (callback) {
+  del(['styleguide', '_site/styleguide']);
+  callback();
 });
 
 // -----------------------------------------------------------------------------
@@ -571,12 +577,12 @@ gulp.task('clean:styleguide', function(callback) {
  *
  * Updates Ruby gems.
  */
-gulp.task('update:gems', function() {
-    return gulp.src('')
-        .pipe(run('bundle install'))
-        .pipe(run('bundle update'))
-        .pipe(notify({ message: 'Bundle Update Complete' }))
-        .on('error', gutil.log);
+gulp.task('update:gems', function () {
+  return gulp.src('')
+    .pipe(run('bundle install'))
+    .pipe(run('bundle update'))
+    .pipe(notify({message: 'Bundle Update Complete'}))
+    .on('error', gutil.log);
 });
 
 /**
@@ -584,8 +590,8 @@ gulp.task('update:gems', function() {
  *
  * Clears the gulp cache. Currently this just holds processed images.
  */
-gulp.task('cache-clear', function(done) {
-    return cache.clearAll(done);
+gulp.task('cache-clear', function (done) {
+  return cache.clearAll(done);
 });
 
 /**
@@ -609,22 +615,24 @@ gulp.task('cache-clear', function(done) {
  *
  * We're also skipping redirect pages like /news/* and /team/*.
  */
-gulp.task('accessibility-test', function() {
-    console.log('Auditing for accessibility...');
-    return gulp.src(paths.htmlTestFiles)
+gulp.task('accessibility-test', function () {
+  console.log('Auditing for accessibility...');
+  return gulp.src(paths.htmlTestFiles)
     .pipe(accessibility({
-        force: false,
-        accessibilityLevel: 'WCAG2A',
-        reportLevels: { notice: false, warning: true, error: true },
-        ignore: [
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H49.I',
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H48',
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H49.AlignAttr',
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H73.3.NoSummary',
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H39.3.NoCaption',
-          'WCAG2A.Principle1.Guideline1_3.1_3_1.H42'
-        ]
+      force: false,
+      accessibilityLevel: 'WCAG2A',
+      reportLevels: {notice: false, warning: true, error: true},
+      ignore: [
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H49.I',
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H48',
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H49.AlignAttr',
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H73.3.NoSummary',
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H39.3.NoCaption',
+        'WCAG2A.Principle1.Guideline1_3.1_3_1.H42'
+      ]
     }))
-      .on('error', console.log)
-      .on('end', function(){ console.log('Accessibility audit complete'); });
+    .on('error', console.log)
+    .on('end', function () {
+      console.log('Accessibility audit complete');
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,6 +1084,38 @@
         }
       }
     },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
+      }
+    },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
@@ -5739,6 +5771,18 @@
         "gulp-util": "3.0.8",
         "read-file": "0.2.0",
         "through2": "2.0.3"
+      }
+    },
+    "gulp-babel": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-7.0.0.tgz",
+      "integrity": "sha512-TiUuFLW6FD2hx3mJ7QBPXN2nzpu6gRWFyjfChWxE1A9xaASRA5nsxrvHcqMDl5Ha6TvSBB9r74GbkVd1GO4mDA==",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "gulp-cache": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp": "^3.9.1",
     "gulp-accessibility": "^3.0.1",
     "gulp-append-prepend": "^1.0.3",
+    "gulp-babel": "^7.0.0",
     "gulp-cache": "^0.4.6",
     "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "babel": {
     "presets": [
       "env",
-      "react"
+      "react",
+      "es2015"
     ]
   },
   "author": "Savas Labs <info@savaslabs.com>",
@@ -25,6 +26,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "browser-sync": "^2.14.0",
     "del": "^2.2.2",


### PR DESCRIPTION
Fixes issue [#4961](https://pm.savaslabs.com/issues/4961)

## Summary of changes

1. Standardizes code style across JS files
2. Mostly fixing indentation and avoiding the use of `var`
3. Including the `es2015` babel preset so we can use es6 in our main JS file and compile it to compatible JS with gulp

## To test

- [x] Pull code and run `gulp clean && gulp serve` to ensure JS is processed without errors and site functions (try out the mobile menu and comments app)

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment

