### PR TITLE
Hide Google Analytics from dev / staging envs

### DIFF
--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,2 +1,4 @@
 comment_server_url: "http://local.comments.savaslabs.com"
 comment_server_enabled: 1
+# Used to determine if Google Analytics should be tracking
+is_production: 0

--- a/_config.test.yml
+++ b/_config.test.yml
@@ -1,3 +1,5 @@
 title: Savas Labs
 baseurl: ""
 url: ""
+# Used to determine if Google Analytics should be tracking
+is_production: 0

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ url: "https://savaslabs.com"
 comment_server_url: "https://squabble.savaslabs.com"
 comment_server_enabled: 1
 
+# Used to determine if Google Analytics should be tracking
+is_production: 1
+
 # Professional and social media links
 twitter_username: savas_labs
 github_username: savaslabs

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,8 @@
   {% if page.layout == "team" %}{% include schema-team.html %}{% endif %}
   {% if page.permalink == "/services/" %}{% include schema-professional-service.html %}{% endif %}
   {% if page.path contains "_posts" %}{% include schema-blog.html %}{% endif %}
-  {% include googleanalytics.html %}
+  {% if site.is_production == 1 %}{% include googleanalytics.html %}{% endif %}
+
 
   <!-- Load main CSS file asynchronously via loadCSS. -->
   <script>


### PR DESCRIPTION
Fixes issue [#5029](https://pm.savaslabs.com/issues/5029)

## Summary of changes

I made come config updates to verify whether the site is building in production or not. Now that I'm writing this, perhaps we've handled this another way in the past?

## Notes

I'm not sure this was the best way to do it, but with local testing it worked as expected. 

## To test

Verify approach is the simplest (not duplicating some other way to verify if we're on production or not) and that syntax seems sane. 

### Pull request reviewer





Include the following for blog posts (delete otherwise):

- [ ] I have reviewed the post for clarity, relevance, and tone
- [ ] I have confirmed that a featured image exists for the post
- [ ] I have run the post through Grammarly and noted any issues to the author
- [ ] If this is a Drupal post, it has the `drupal-planet` tag and the
`drupal_planet_summary` front matter element
