### PR TITLE
Tasks #4975 and #5057: article typography improvements

### DIFF
--- a/_assets/styles/scss/01-base/_mixins.scss
+++ b/_assets/styles/scss/01-base/_mixins.scss
@@ -57,6 +57,12 @@
   }
 }
 
+@mixin post-text() {
+  font-family: $post-font;
+  font-size: 1.125em;
+  line-height: 1.625;
+}
+
 @mixin ease() {
   transition: all .2s ease-in-out;
 }

--- a/_assets/styles/scss/03-typography/_blockquote.scss
+++ b/_assets/styles/scss/03-typography/_blockquote.scss
@@ -55,9 +55,9 @@ blockquote {
     border-bottom: solid 1px $light-orange;
   }
 
+  // Note: font size for p is set in `_paragraphs.scss` to avoid specificity
+  // issues.
   p {
-    @include paragraph-loud-responsive;
-
     color: lighten($teal, 10%);
     // scss-lint:disable ImportantRule
     margin-bottom: 0 !important;
@@ -78,6 +78,7 @@ blockquote {
   span {
     color: $grey;
     display: block;
+    font-size: .8em;
     margin-top: .5em;
 
     @include grid-media($medium-screen-up) {

--- a/_assets/styles/scss/03-typography/_lists.scss
+++ b/_assets/styles/scss/03-typography/_lists.scss
@@ -2,7 +2,6 @@
  * @file
  *
  * Typography: list styles.
- * Note: See _paragraphs.scss for some blog-post-specific list styles.
  */
 
 /*doc
@@ -60,3 +59,20 @@ ol p {
   font-size: 1em !important;
 }
 // scss-lint:enable ImportantRule
+
+// Article styles.
+article {
+  ol,
+  ul {
+    @include post-text;
+  }
+
+  li {
+    margin-bottom: .325em;
+
+    // Nested list items need top margin to keep spacing consistent.
+    li {
+      margin-top: .325em;
+    }
+  }
+}

--- a/_assets/styles/scss/03-typography/_paragraphs.scss
+++ b/_assets/styles/scss/03-typography/_paragraphs.scss
@@ -54,8 +54,8 @@ article {
     margin-bottom: 1em;
   }
 
-  li {
-    margin-bottom: .325em;
+  blockquote p {
+    font-size: 1.4em;
   }
 }
 

--- a/_assets/styles/scss/03-typography/_paragraphs.scss
+++ b/_assets/styles/scss/03-typography/_paragraphs.scss
@@ -45,12 +45,8 @@ article {
   color: $dark-teal;
   word-wrap: break-word;
 
-  p,
-  ol,
-  ul {
-    font-family: $post-font;
-    font-size: 1.125em;
-    line-height: 1.625;
+  p {
+    @include post-text;
     margin-bottom: 1em;
   }
 


### PR DESCRIPTION
Fixes issues [#4975](https://pm.savaslabs.com/issues/4975) and  [#5057](https://pm.savaslabs.com/issues/5057)

## Summary of changes

1. Bumps up blockquote font size. Our previous styles to make blockquote text larger were being overridden due to a specificity issue I have now fixed. The attribution span is a bit smaller than the blockquote text - let me know what you think.
2. Makes space between list items consistent. Check out the list on the marketing director page as well as the list in [this section](http://localhost:3000/2016/10/19/optimizing-jekyll-with-gulp.html#motivation) - all list items, nested or not, should be the same distance from the surrounding ones.

## Notes

Assumptions, caveats, warnings, etc

## To test

- Run `gulp clean && gulp serve`
- Check out your recent blog post to see new blockquote styles
- Check out the pages mentioned above to see the list styles
- Let me know what you think!

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment
