### PR TITLE
Issue #5119: Add job posting schema

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,6 +19,9 @@
   {% if page.layout == "team" %}{% include schema-team.html %}{% endif %}
   {% if page.permalink == "/services/" %}{% include schema-professional-service.html %}{% endif %}
   {% if page.path contains "_posts" %}{% include schema-blog.html %}{% endif %}
+  {% if page.permalink == "/careers/marketing-director/" %}{% include schema-marketing-director.html %}{% endif %}
+
+  <!-- Google Analytics. -->
   {% if site.is_production == 1 %}{% include googleanalytics.html %}{% endif %}
 
 

--- a/_includes/schema-blog.html
+++ b/_includes/schema-blog.html
@@ -42,7 +42,8 @@
         "@type": "Organization",
         "address": {
           "@type": "PostalAddress",
-          "addressLocality": "Durham, North Carolina",
+          "addressLocality": "Durham",
+          "addressRegion": "NC",
           "postalCode": "27701",
           "streetAddress": "201 W Main St."
         },

--- a/_includes/schema-marketing-director.html
+++ b/_includes/schema-marketing-director.html
@@ -1,0 +1,50 @@
+{% assign logo = '/assets/img/logo.png' %}
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "JobPosting",
+    "datePosted": "2017-11-15",
+    "description": "Savas Labs is a cohesive team of outstanding individuals with complementary skill sets. We’re looking to greatly expand our reach to get our expertise in the hands of those who could benefit most from it. The Marketing Director will fulfill our first full-time marketing position. We’re looking for someone with the creativity and drive to help shape the marketing vision coupled with the relevant experience to execute it. The marketing director will work directly with the Savas Labs Principal Director to formulate, select tools for, and implement our marketing strategy in our Durham, NC office.",
+    "employmentType": "FULL_TIME",
+    "experienceRequirements": "An ideal candidate will have professional experience with a majority of the following: Initiating and managing an at-least monthly newsletter, marketing automation systems, CRM systems, content creation, persona targeting, managing ad campaigns, Drupal CMS, 5+ years B2B marketing.",
+    "hiringOrganization": {
+      "@context": "http://schema.org",
+      "@type": "Organization",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Durham",
+        "addressRegion": "NC",
+        "postalCode": "27701",
+        "streetAddress": "201 W Main St."
+      },
+      "description": "{{ site.description }}",
+      "email": "info@savaslabs.com",
+      "logo": {
+        "@context": "http://schema.org",
+        "@type": "ImageObject",
+        "description": "Savas Labs logo",
+        "height": "50px",
+        "url": "{{ logo | prepend: site.url }}",
+        "width": "114px"
+      },
+      "name": "Savas Labs",
+      "telephone": "(919) 432-4660",
+      "url": "{{ site.url }}"
+    },
+    "industry": "Web Services",
+    "jobLocation": {
+      "@type": "Place",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Durham",
+        "addressRegion": "NC",
+        "postalCode": "27701",
+        "streetAddress": "201 W Main St."
+      }
+    },
+    "qualifications": "An ideal candidate will have professional experience with a majority of the following: Initiating and managing an at-least monthly newsletter, marketing automation systems, CRM systems, content creation, persona targeting, managing ad campaigns, Drupal CMS, 5+ years B2B marketing.",
+    "responsibilities": "Work with leadership to refine target market, build brand awareness and positioning, align marketing goals with business strategy, coordinate marketing activities to meet goals and deadlines, set and monitor key performance indicators to optimize marketing plans, support sales efforts with inbound marketing.",
+    "title": "Marketing Director",
+    "workHours": "Flexible"
+  }
+</script>

--- a/_includes/schema-organization.html
+++ b/_includes/schema-organization.html
@@ -5,7 +5,8 @@
     "@type": "Organization",
     "address": {
       "@type": "PostalAddress",
-      "addressLocality": "Durham, North Carolina",
+      "addressLocality": "Durham",
+      "addressRegion": "NC",
       "postalCode": "27701",
       "streetAddress": "201 W Main St."
     },
@@ -21,7 +22,7 @@
     },
     "name": "Savas Labs",
     "telephone": "(919) 432-4660",
-    "url": "{{ site.url }}"
+    "url": "{{ site.url }}",
     "sameAs": [
       "http://twitter.com/savas_labs",
       "https://www.linkedin.com/company/savas-labs"

--- a/_includes/schema-professional-service.html
+++ b/_includes/schema-professional-service.html
@@ -5,7 +5,8 @@
       "@type": "ProfessionalService",
       "address": {
         "@type": "PostalAddress",
-        "addressLocality": "Durham, North Carolina",
+        "addressLocality": "Durham",
+        "addressRegion": "NC",
         "postalCode": "27701",
         "streetAddress": "201 W Main St."
       },


### PR DESCRIPTION
Fixes issue [#5119](https://pm.savaslabs.com/issues/5119)

## Summary of changes

1. Adds JobPosting schema for the marketing director posting
2. Fixes a couple of errors in other schema scripts

## Notes

There are a few recommended items for JobPostings that we're not including:

- Base salary
- Education requirements
- Skills
- Valid through

Let me know if you'd like to include information for any of these.

I've also duplicated the "required experience" items for the "qualifications" field. Let me know if you'd like to differentiate these at all.

Creating this script was a manual process of copy/pasting from the job posting. If we foresee posting a lot of jobs in the future we could add front matter items for schema data, but I didn't think it was worth spending the time on that now, especially as we discuss moving to a platform other than Jekyll.

## To test

- Review the data in the marketing director schema JSON file
- I tested this locally via ngrok and Google's structured data testing tool. We'll probably want to run the live site through the tool after this is launched just to confirm it's not throwing errors. We will get warnings for the 4 items listed above that we're not including in the data.
