### PR TITLE
Issue #5119: Change hiring organization email

### DIFF
--- a/_includes/schema-marketing-director.html
+++ b/_includes/schema-marketing-director.html
@@ -18,7 +18,7 @@
         "streetAddress": "201 W Main St."
       },
       "description": "{{ site.description }}",
-      "email": "info@savaslabs.com",
+      "email": "careers@savaslabs.com",
       "logo": {
         "@context": "http://schema.org",
         "@type": "ImageObject",


### PR DESCRIPTION
Fixes issue [#5119](https://pm.savaslabs.com/issues/5119)

## Summary of changes

Updates the hiring organization email to careers instead of info

## Notes

@chrisarusso Opening this PR for posterity; I'm going to merge
