### PR TITLE
Issue #5609: fix empty heading link text

### DIFF
--- a/_assets/js/global/main.js
+++ b/_assets/js/global/main.js
@@ -44,7 +44,7 @@ $(document).ready(
   function () {
     'use strict';
     $('article h2, article h3, article h4, article h5, article h6').filter('[id]').each(function () {
-      $(this).append('<a class="heading-link" href="#' + $(this).attr('id') + '"><i class="fa fa-link"></i></a>');
+      $(this).append('<a class="heading-link" href="#' + $(this).attr('id') + '"><i class="fa fa-link"></i><span class="sr-only">Copy link to heading</span></a>');
     });
   });
 


### PR DESCRIPTION
Fixes issue [#5609](https://pm.savaslabs.com/issues/5609)

## Summary of changes

1. Adds text to the heading links within posts that's hidden with CSS to make these links accessible to screen readers

## To test

- [x] Run `gulp clean && gulp serve`
- [x] Review the heading links on a blog post - ensure the new text isn't visible but that it exists in the markup

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment