### PR TITLE
Issue #4956: Don't bother caching images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
   - directories:
       - "node_modules"
       - "vendor"
-      - "assets/img"
 
 script:
   - ./_scripts/run-tests.sh

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -397,24 +397,13 @@ gulp.task('clean', ['clean:jekyll',
   'clean:styleguide']);
 
 /**
- * Task: clean:prod
- *
- * Runs all clean commands except images, which are cached by Travis.
- */
-gulp.task('clean:prod', ['clean:jekyll',
-  'clean:fonts',
-  'clean:scripts',
-  'clean:styles',
-  'clean:styleguide']);
-
-/**
  * Task: build
  *
  * Build the site anew. Assumes images are cached by Travis.
  */
 gulp.task('build', function (callback) {
-  runSequence('clean:prod',
-    ['build:scripts', 'build:styles', 'build:fonts'],
+  runSequence('clean',
+    ['build:scripts', 'build:images', 'build:styles', 'build:fonts'],
     'styleguide',
     'build:jekyll',
     callback);


### PR DESCRIPTION
Now that we're not including image processing in an automated
gulp task, we don't really need to, and it seems to have been
breaking the Travis build.