### PR TITLE
Issue #5959: improve code styles

### DIFF
--- a/_assets/styles/scss/01-base/_variables.scss
+++ b/_assets/styles/scss/01-base/_variables.scss
@@ -83,7 +83,7 @@ $expander-toggle-arrow-size: $expander-toggle-size;
 $expander-toggle-margin: 1em;
 
 // Syntax highlighting ---------------------------------------------------------
-$noise-bg: url('assets/img/noise.png') top left !default;
+$noise-bg: url('../../assets/img/noise.png') top left !default;
 
 // Syntax highlighting is based off a Sass port of the Solarized theme,
 // created by Brandon Mathis at Octopress.

--- a/_assets/styles/scss/03-typography/_code--inline.scss
+++ b/_assets/styles/scss/03-typography/_code--inline.scss
@@ -32,7 +32,7 @@ the MySQL server.</p>
 // scss-lint:disable ImportantRule
 p,
 li {
-  code {
+  > code {
     background: $base-background-color;
     border: 1px solid $light-gray;
     border-radius: .2em;

--- a/_assets/styles/scss/03-typography/_code.scss
+++ b/_assets/styles/scss/03-typography/_code.scss
@@ -45,43 +45,81 @@ sass port of the Solarized theme. See
 
 */
 
+$solar-scroll-bg: rgba(#fff, .15);
+$solar-scroll-thumb: rgba(#fff, .2);
+@if $solarized == light {
+  $solar-scroll-bg: rgba(#000, .15);
+  $solar-scroll-thumb: rgba(#000, .15);
+}
+
 .highlight {
-  table td.code { width: 100%; }
-  border: 1px solid $light-gray !important;
+  background: #ddd;
   border-radius: .4em;
   margin: 0 1.5em 1.5em !important;
-}
+  overflow-x: auto;
+  overflow-y: hidden;
 
-.highlight .line-numbers {
-  text-align: right;
-  font-size: 13px;
-  line-height: 1.45em;
-  @if $solarized == light {
-    background: lighten($base03, 1) $noise-bg !important;
-    border-right: 1px solid darken($base01, 2) !important;
-    box-shadow: lighten($base03, 2) -1px 0 inset;
-    text-shadow: lighten($base01, 2) 0 -1px;
-  } @else {
-    background: $base01 $noise-bg !important;
-    border-right: 1px solid darken($base03, 2) !important;
-    box-shadow: lighten($base01, 2) -1px 0 inset;
-    text-shadow: darken($base01, 10) 0 -1px;
+  &::-webkit-scrollbar {
+    background: $solar-scroll-bg;
+    height: .5em;
   }
-  span { color: $base01 !important; }
-  padding: .8em !important;
-  border-radius: 0;
+
+  &::-webkit-scrollbar-thumb:horizontal {
+    background: $solar-scroll-thumb;
+    border-radius: 4px
+  }
+
+  pre {
+    background: none;
+    box-shadow: none;
+    margin-bottom: 0;
+    padding: 0;
+  }
+
+  code {
+    @extend .pre-code;
+    background: #fff !important;
+  }
+
+  .line-numbers {
+    border-radius: 0;
+    font-size: 13px;
+    line-height: 1.45em;
+    padding: .8em !important;
+    text-align: right;
+
+    @if $solarized == light {
+      background: lighten($base03, 1) $noise-bg !important;
+      border-right: 1px solid darken($base01, 2) !important;
+      box-shadow: lighten($base03, 2) -1px 0 inset;
+      text-shadow: lighten($base01, 2) 0 -1px;
+    } @else {
+      background: $base01 $noise-bg !important;
+      border-right: 1px solid darken($base03, 2) !important;
+      box-shadow: lighten($base01, 2) -1px 0 inset;
+      text-shadow: darken($base01, 10) 0 -1px;
+    }
+
+    span {
+      color: $base01 !important;
+    }
+  }
+
+  table td.code {
+    width: 100%;
+  }
 }
 
-figure.code, pre {
+figure.code,
+pre {
   box-shadow: rgba(#000, .06) 0 0 10px;
-  .highlight pre { box-shadow: none; }
 }
 
 pre {
   background: $pre-bg $noise-bg;
+  border: 1px solid $light-gray;
   border-radius: .4em;
   font-family: $monospace-font !important;
-  border: 1px solid $pre-border;
   line-height: 1.45em;
   font-size: 13px !important;
   margin: 0;
@@ -93,7 +131,7 @@ pre {
   }
 }
 
-.pre-code {
+pre code {
   font-family: $monospace-font !important;
   overflow: scroll;
   overflow-y: hidden;
@@ -101,7 +139,6 @@ pre {
   padding: .8em;
   overflow-x: auto;
   line-height: 1.45em;
-  background: $base03 $noise-bg !important;
   color: $base1 !important;
   span { color: $base1 !important; }
   span { font-style: normal !important; font-weight: normal !important; }
@@ -172,63 +209,22 @@ pre {
   div { .gd, .gd .x, .gi, .gi .x { display: inline-block; width: 100%; }}
 }
 
-.highlight {
-  pre { background: none; border-radius: 0; border: none; padding: 0; margin-bottom: 0; }
-  margin: 0 3em 1.5em;
-  background: #ddd;
-  overflow-y: hidden;
-  overflow-x: auto;
-}
-
-$solar-scroll-bg: rgba(#fff, .15);
-$solar-scroll-thumb: rgba(#fff, .2);
-@if $solarized == light {
-  $solar-scroll-bg: rgba(#000, .15);
-  $solar-scroll-thumb: rgba(#000, .15);
-}
-
-pre, .highlight {
-  &::-webkit-scrollbar {  height: .5em; background: $solar-scroll-bg; }
-  &::-webkit-scrollbar-thumb:horizontal { background: $solar-scroll-thumb;  -webkit-border-radius: 4px; border-radius: 4px }
-}
-
-.highlight code {
-  @extend .pre-code;
-  background: #fff !important;
-}
-
-figure.code {
-  background: none;
-  padding: 0;
-  border: 0;
-  margin-bottom: 1.5em;
-  pre { margin-bottom: 0; }
-  figcaption {
-    position: relative;
-    @extend .code-title;
-    a { @extend .download-source; }
-  }
-  .highlight {
-    margin-bottom: 0;
-  }
-}
-
 .code-title {
-  text-align: center;
-  font-size: 13px;
-  line-height: 2em;
-  text-shadow: #cbcccc 0 1px 0;
-  color: #474747;
-  font-weight: normal;
-  margin-bottom: 0;
   @include border-top-radius(5px);
-  font-family: "Helvetica Neue", Arial, "Lucida Grande", "Lucida Sans Unicode", Lucida, sans-serif;
+
   background: #aaaaaa top repeat-x;
-  border: 1px solid #565656;
-  border-top-color: #cbcbcb;
-  border-left-color: #a5a5a5;
-  border-right-color: #a5a5a5;
   border-bottom: 0;
+  border-left: 1px solid #a5a5a5;
+  border-right: 1px solid #a5a5a5;
+  border-top: 1px solid #cbcbcb;
+  color: #474747;
+  font-family: "Helvetica Neue", Arial, "Lucida Grande", "Lucida Sans Unicode", Lucida, sans-serif;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 2em;
+  margin-bottom: 0;
+  text-align: center;
+  text-shadow: #cbcccc 0 1px 0;
 }
 
 .download-source {
@@ -238,6 +234,31 @@ figure.code {
   font-size: 13px;
   text-shadow: #cbcccc 0 1px 0;
   padding-left: 3em;
+}
+
+figure.code {
+  background: none;
+  border: 0;
+  margin-bottom: 1.5em;
+  padding: 0;
+
+  pre {
+    margin-bottom: 0;
+  }
+
+  figcaption {
+    @extend .code-title;
+
+    position: relative;
+
+    a {
+      @extend .download-source;
+    }
+  }
+
+  .highlight {
+    margin-bottom: 0;
+  }
 }
 
 .highlight-console .pre-code {

--- a/_assets/styles/scss/03-typography/_code.scss
+++ b/_assets/styles/scss/03-typography/_code.scss
@@ -55,9 +55,13 @@ $solar-scroll-thumb: rgba(#fff, .2);
 .highlight {
   background: #ddd;
   border-radius: .4em;
-  margin: 0 1.5em 1.5em !important;
+  margin: 0 0 1.5em !important;
   overflow-x: auto;
   overflow-y: hidden;
+
+  @include grid-media($medium-screen-up) {
+    margin: 0 1.5em 1.5em !important;
+  }
 
   &::-webkit-scrollbar {
     background: $solar-scroll-bg;

--- a/_posts/2015-04-02-css-testing.markdown
+++ b/_posts/2015-04-02-css-testing.markdown
@@ -23,7 +23,6 @@ Writing CSS is easy. Writing good, semantic, DRY CSS, all while avoiding uninten
 
 Note: most of the techniques I tested require the node package manager (npm) for installation. Check out [the npm docs](https://docs.npmjs.com/getting-started/installing-node) for installation instructions.
 
-
 ### Syntax checks & house/project styleguide
 
 #### CSS Lint
@@ -37,7 +36,6 @@ Savas Labs uses the [SCSS-Lint Ruby gem](https://github.com/brigade/scss-lint) o
 #### StyleStats
 
 [Stylestats](https://github.com/t32k/stylestats) provides stylesheet statistics and is useful in tandem with CSS Lint. It works on single stylesheets or a directory of them, or globbing can be used (don't forget the quotes, e.g. `stylestats 'styles/*.css'`). Stylestats will report the number and size of your stylesheets, simplicity (# rules/# selectors), unique font sizes, number of ID selectors used, and other pertinent information.
-
 
 ### Image Diff
 
@@ -53,7 +51,6 @@ BackstopJS is a cinch to install and configure ([this article](https://css-trick
 
 Created by BBC News, [Wraith](http://bbc-news.github.io/wraith/index.html) compares a local/dev/staging site against the live site, much more useful for sites with dynamic content than a set of baseline images that would quickly become outdated. A major downside is that the testing process is more manual than Backstop since Wraith doesn't output a report - the CLI states whether or not there were failures, but it's up to the tester to find them in individual images or a gallery of all the diffs. The image diffs show differences down to the pixel in bright blue, but they still have to be found manually. Still, Wraith would be a valuable tool for large Drupal sites. For smaller or non-Drupal sites, I'd stick with Backstop.
 
-
 ### Computed Style
 
 #### Hardy
@@ -62,10 +59,8 @@ Created by BBC News, [Wraith](http://bbc-news.github.io/wraith/index.html) compa
 
 Because of the time-consuming nature of creating the tests, I would reserve the use of Hardy for large theming projects in which avoiding CSS regression errors is key.
 
-
 ## Further reading
 
 - <a href="http://csste.st/">csste.st</a> - A good place to start.
 - A nice <a href="https://css-tricks.com/automatic-css-testing/">summary</a> of automated testing techniques.
 - An excellent introductory <a href="http://code.tutsplus.com/tutorials/object-oriented-css-what-how-and-why--net-6986">tutorial</a> on object oriented CSS.
-

--- a/_posts/2015-06-10-d8-theming-basics.markdown
+++ b/_posts/2015-06-10-d8-theming-basics.markdown
@@ -55,7 +55,6 @@ Though the theming layer in Drupal 8 is quite different from Drupal 7 and will r
 - More semantic CSS class names means leaner CSS and a more readable DOM
 - A general trend towards more extendable, modular, well-organized, better-performing code
 
-
 ## Okay, are there any disadvantages?
 
 At the time of writing this post, the toughest things about theming in Drupal 8 for me were:
@@ -114,7 +113,6 @@ regions:
 
 This hasn't changed much from Drupal 7. Don't forget that the `Content` region is required. You can also forego declaring regions if you want to use Drupal's [default regions.](https://www.drupal.org/node/2469113)
 
-
 ### Classy, the new base theme
 
 ```yaml
@@ -124,7 +122,6 @@ base theme: classy
 Classy is a brand new base theme that ships with Drupal core. All CSS classes were moved out of core template files and into Classy's as a way to a) contain, minimize, and organize default classes and b) give developers the option of not using Drupal's default classes without having to undo core. One can simply choose not to use Classy as a base theme.
 
 Additionally, Classy's classes follow the BEM convention, making them less generic and more meaningful. Check out [this article](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/) for a great introduction to BEM.
-
 
 ### Libraries
 
@@ -160,7 +157,6 @@ As you may have guessed, `global-styling` is a library that applies site-wide st
 
 By listing these two libraries in `mappy.info.yml` we ensure that these assets will be included on every page of our site. However, this is typically not the best practice for larger sites since these files can seriously affect performance. [This page](https://www.drupal.org/developing/api/8/assets) on Drupal.org details how to attach assets to pages via hooks so that CSS and JS files are only loaded where they're needed.
 
-
 ### Breakpoints
 Another new YAML file, `[theme-name].breakpoints.yml`, allows developers to create standard breakpoints to be used by modules and themes across the site. You can set custom breakpoints by defining them in this file. Below is our breakpoints file, which also resides in the root of our theme. Note that we simply adapted the breakpoints file from the Bartik theme.
 
@@ -189,7 +185,6 @@ mappy.wide:
 Important tip: Once you add a breakpoints file, you'll need to uninstall and reinstall your theme to expose these breakpoints in the admin UI.
 
 With these files set up, you now have a working custom theme!
-
 
 ## Creating template files with Twig
 
@@ -284,7 +279,6 @@ Another useful tag is `set`, which allows you to set and use variables throughou
 ### Coding standards
 
 Since this is new to some Drupalers, take a moment to check out the [coding standards](https://www.drupal.org/node/1823416) for Twig.
-
 
 ## Debugging with Twig
 
@@ -381,7 +375,6 @@ Enter the beloved Devel module and the new Devel Kint module. Kint is to Drupal 
 <img src="{{ site.base_url }}/assets/img/blog/kint-output.jpg" alt="Screenshot of kint function output.">
 
 Ahh, much better!
-
 
 ## Further reading:
 - Start with Drupal.org's [theming guide](https://www.drupal.org/theme-guide/8)


### PR DESCRIPTION
Fixes issue [#5959](https://pm.savaslabs.com/issues/5959)

## Summary of changes

1. Updates some CSS selectors to ensure code is being styled. This was necessary after we updated the `rouge` gem and code output changed slightly
2. Fixed margin of code blocks on mobile so they can be a bit wider
3. Organized and cleaned up the syntax highlighting file
4. Fixed some markdown files that popped up on tests

## To test

- [x] `gulp clean && gulp serve --rebuild`
- [x] Check out a couple of posts with some code like http://localhost:3000/2017/02/15/docker-mysql-performance.html and http://localhost:3000/2016/10/19/optimizing-jekyll-with-gulp.html
- [x] Confirm syntax highlighting is working now and that inline code and code blocks are styled properly with colorful text
- [x] Shrink your browser - under 650px width the left and right margins around code blocks will disappear so the code can be a bit wider

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment


