### PR TITLE
Issue #7627: Update ITA case study summary

### DIFF
--- a/_case-studies/darden-ita.md
+++ b/_case-studies/darden-ita.md
@@ -15,8 +15,6 @@ client_description: |
 client_dates: 2018 - Present
 project_highlights: [Drupal 8, Content Migration, UX design and implementation, Client Training]
 project_description: |
-  Content Migration / Redesign
-
   To secure their place as one of the country’s top business schools, the Darden School of Business sought to redesign and rebuild their web properties in Drupal 8. Partnering closely with peer agency Viget on design, Savas Labs consulted throughout the design process and engineered the new Drupal 8 site.
 description: |
   To secure their place as one of the country’s top business schools, the Darden School of Business sought to redesign and rebuild their web properties in Drupal 8. Partnering closely with peer agency Viget on design, Savas Labs consulted throughout the design process and engineered the new Drupal 8 site.


### PR DESCRIPTION
Fixes issue [#7627](https://pm.savaslabs.com/issues/7627)

## Summary of changes

1. Removes "Content Migration/Redesign" from the Darden ITA case study's `project_description`

## Notes 
The branch issue number is wrong - my apologies. 

## To test

- [x] Review https://stage2--savas-staging.netlify.com/results/case-studies/darden-ita/
- [x] Confirm the text at the top left under the case study title begins with: "To secure their place as one of the country’s top business schools," **and not:** "Content Migration/Redesign"

### Pull request reviewer

As the reviewer, I have verified the following:

- [x] I have tested the PR locally and/or in a staging environment