### PR TITLE
Issue #9400: Replace blog snippets with summaries

### DIFF
--- a/_posts/2019-07-03-savas-brings-on-another-front-end-developer.md
+++ b/_posts/2019-07-03-savas-brings-on-another-front-end-developer.md
@@ -4,8 +4,8 @@ title: "Savas Brings on Another Front-end Developer"
 date: 2019-07-03
 author: Madeline Streilein
 tags: team company-culture
-summary: “Hello Savas Labs fans! My name is Madeline Streilein and I am one of Savas’ two brand new Junior Front-end Developers (Alex Manzo also joined our burgeoning front-end squad under the tutelage of Anne Tomasevich - keep an eye out for their introduction).“
-description: “Hello Savas Labs fans! My name is Madeline Streilein and I am one of Savas’ two brand new Junior Front-end Developers (Alex Manzo also joined our burgeoning front-end squad under the tutelage of Anne Tomasevich - keep an eye out for their introduction).“
+summary: Get to know Savas' newest Junior Front-end Developer, find out why she chose Savas and read a couple of her best dad jokes.
+description: Get to know Savas' newest Junior Front-end Developer, find out why she chose Savas and read a couple of her best dad jokes.
 image: "/assets/img/blog/madeline-dan-computer.jpg"
 featured_image: "/blog/madeline-dan-computer.jpg"
 featured_image_alt: "Madeline and Dan working on computer."

--- a/_posts/2019-07-30-savas-expands-development-team-meet-alex-manzo.md
+++ b/_posts/2019-07-30-savas-expands-development-team-meet-alex-manzo.md
@@ -4,8 +4,8 @@ title: "Savas Expands Development Team: Meet Alex Manzo"
 date: 2019-07-30
 author: Alex Manzo
 tags: team company-culture
-summary: “I am beyond thrilled to join the Savas Labs team as a junior front-end developer. I came to Savas after a year working with NETE. Before that, I spent my days, nights, and weekends working in athletics video production. I’m probably the only member of the Savas team who could produce a live basketball broadcast without breaking a sweat.“
-description: “I am beyond thrilled to join the Savas Labs team as a junior front-end developer. I came to Savas after a year working with NETE. Before that, I spent my days, nights, and weekends working in athletics video production. I’m probably the only member of the Savas team who could produce a live basketball broadcast without breaking a sweat.“
+summary: "Our newest Junior Front-End Developer joins us with a love of dogs (their dog even joined us at the office one day!) and the best gif game you've ever seen."
+description: "Our newest Junior Front-End Developer joins us with a love of dogs (their dog even joined us at the office one day!) and the best gif game you've ever seen."
 image: "/assets/img/blog/alex-maddy-computer.jpg"
 featured_image: "/blog/alex-maddy-computer.jpg"
 featured_image_alt: "Alex and Maddy collaborating."

--- a/_posts/2019-08-05-our-team-keeps-getting-bigger-meet-kayla-morales.md
+++ b/_posts/2019-08-05-our-team-keeps-getting-bigger-meet-kayla-morales.md
@@ -4,8 +4,8 @@ title: "Our Team Keeps Getting Bigger: Meet Kayla Morales"
 date: 2019-08-05
 author: Jordan Nelson and Kayla Morales
 tags: team company-culture
-summary: “Kayla joins as our newest Project Manager. In between her busy days onboarding with Maddy, getting acclimated to the office, and taking on projects of her own, we caught up and I asked some questions for us all to get to know her a bit better. So, without further ado, let’s meet Kayla!“
-description: “Kayla joins as our newest Project Manager. In between her busy days onboarding with Maddy, getting acclimated to the office, and taking on projects of her own, we caught up and I asked some questions for us all to get to know her a bit better. So, without further ado, let’s meet Kayla!“
+summary: We interviewed Kayla to learn more about her story, what she brings to the Savas team, and her love of reading!
+description: We interviewed Kayla to learn more about her story, what she brings to the Savas team, and her love of reading!
 image: "/assets/img/blog/kayla-and-jordan.JPG"
 featured_image: "/blog/kayla-and-jordan.JPG"
 featured_image_alt: "Kayla and Jordan on computer."


### PR DESCRIPTION
Fixes issue [#9400](https://pm.savaslabs.com/issues/9400)

## Summary of changes

1. Changes `Our Team Keeps Getting Bigger: Meet Kayla Morales` blog summary to:
> We interviewed Kayla to learn more about her story, what she brings to the Savas team, and her love of reading!"

2. Change `Savas Expands Development Team: Meet Alex Manzo` blog summary to: 
> Our newest Junior Front-End Developer joins us with a love of dogs (their dog even joined us at the office one day!) and the best gif game you've ever seen.

3. Change `Savas Brings on Another Front-end Developer` blog summary to:
> Get to know Savas' newest Junior Front-end Developer, find out why she chose Savas and read a couple of her best dad jokes.

## Notes

Pro(Googler)-tip: The front-matter will not display quotation marks if there are single `'` or double `"` quotes but they will if there are curly `“` quotes.

## To test

- [x] At the bottom of the [homepage](https://stage1--savas-staging.netlify.com/), hover over the blog posts and confirm the summaries match 1 and 2 above
- [x] Ensure none of the summaries show quotation marks
- [x] Go to the [blog page ](https://stage1--savas-staging.netlify.com/blog/), hover over the blog post from 3 above and confirm the summary matches
- [x] Ensure none of the summaries show quotation marks
