### PR TITLE
Issue #9827: Remove Digital Project Manager listing from We're Hiring page

### DIFF
--- a/_pages/careers.md
+++ b/_pages/careers.md
@@ -37,8 +37,6 @@ The needs at Savas Labs are continually evolving as we grow, but one constant is
 
 [Senior Front-end Developer](/senior-front-end-developer)
 
-[Digital Project Manager](/digital-project-manager)
-
 [JavaScript Engineer](/javascript-engineer)
 
 

--- a/_posts/2016-09-23-supercharged-seo-with-drupal-8.md
+++ b/_posts/2016-09-23-supercharged-seo-with-drupal-8.md
@@ -43,7 +43,7 @@ Here are four ranking factors that we've identified as being most important as o
 
 ### 1. Content
 
-[Content is still king!](https://mention.com/blog/2017-content-marketing-predictions/) Yes, that's right. It is and it always will be! You've got to be relevant in order to even appear in search. And nothing will make you more relevant than carefully crafted, practical, awesome, juicy, shareable, actionable (you name it) CONTENT! It is important to note that marketers should stop thinking of content as purely text and focus their efforts on providing [visual content](http://blog.hubspot.com/marketing/visual-content-marketing-strategy#sm.00001bvjy82syzedqpgnd8w6p9mw8) that supports storytelling, is engaging and [matches user intent](https://varvy.com/matching-user-intent.html).
+[Content is still king!](ttps://mention.com/en/blog/content-marketing-predictions-for-2017/) Yes, that's right. It is and it always will be! You've got to be relevant in order to even appear in search. And nothing will make you more relevant than carefully crafted, practical, awesome, juicy, shareable, actionable (you name it) CONTENT! It is important to note that marketers should stop thinking of content as purely text and focus their efforts on providing [visual content](http://blog.hubspot.com/marketing/visual-content-marketing-strategy#sm.00001bvjy82syzedqpgnd8w6p9mw8) that supports storytelling, is engaging and [matches user intent](https://varvy.com/matching-user-intent.html).
 
 ### 2. Backlinks
 


### PR DESCRIPTION
Fixes issue [#9827](https://pm.savaslabs.com/issues/9827)

## Summary of changes

1. Removes role from career page

## To test

- [ ] Confirm the role no longer appears on the [careers page](https://stage1--savas-staging.netlify.com/careers/)

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment